### PR TITLE
Docker with GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: "{{ defaultContext }}:maestro-server"
+          context: "./maestro-server"
+          dockerfile: "./maestro-server/Dockerfile"
           platforms: linux/amd64,linux/arm64
           push: true
           tags: datacatering/maestro:0.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build Docker image
+
+on:
+  push:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Gradle build with cache
+        uses: burrunan/gradle-cache-action@v1
+        with:
+          arguments: "bootJar"
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: "{{ defaultContext }}:maestro-server"
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: datacatering/maestro:0.1.0

--- a/maestro-server/Dockerfile
+++ b/maestro-server/Dockerfile
@@ -1,0 +1,11 @@
+FROM openjdk:21-slim as builder
+ARG JAR_FILE=build/libs/maestro-server.jar
+COPY ${JAR_FILE} application.jar
+RUN java -Djarmode=layertools -jar application.jar extract
+
+FROM openjdk:21-slim
+COPY --from=builder dependencies/ ./
+COPY --from=builder snapshot-dependencies/ ./
+COPY --from=builder spring-boot-loader/ ./
+COPY --from=builder application/ ./
+ENTRYPOINT ["java", "-Djava.security.manager=allow", "org.springframework.boot.loader.JarLauncher"]

--- a/maestro-server/README.md
+++ b/maestro-server/README.md
@@ -1,20 +1,8 @@
-# Maestro Server
+Maestro Server
 ===================================
 This module includes a Springboot app implementation of Maestro server.
 
 ## Docker
-
-### Run
-
-Assuming you have cockroachdb already setup and running ([otherwise check these steps](#cockroachdb)):
-
-```shell
-docker run \
-  -p 8080:8080 \
-  -e CONDUCTOR_CONFIGS_JDBCURL=jdbc:postgresql://cockroachdb:26257/maestro \
-  -e CONDUCTOR_CONFIGS_JDBCUSERNAME=root \
-  datacatering/maestro:0.1.0
-```
 
 ### Build
 
@@ -22,24 +10,28 @@ Build the JAR file and Docker image via:
 
 ```shell
 ./gradlew bootJar
-docker build -t maestro-server:0.1 .
+docker build -t maestro-server:0.1 maestro-server
+```
+
+### Run
+
+Assuming you have CockroachDB already setup and running ([otherwise check these steps](#cockroachdb)):
+
+```shell
+docker run \
+  --name maestro \
+  --network host \
+  -p 8080:8080 \
+  -e CONDUCTOR_CONFIGS_JDBCURL=jdbc:postgresql://localhost:26257/maestro \
+  -e CONDUCTOR_CONFIGS_JDBCUSERNAME=root \
+  maestro-server:0.1
 ```
 
 #### CockroachDB
 
-Spin up cockroachdb either yourself or via [insta-infra](https://github.com/data-catering/insta-infra), with database 
-`maestro` created.
+Spin up CockroachDB with `maestro` database via the below commands:
 
 ```shell
-./run.sh cockroach
-./run.sh -c cockroach
-CREATE DATABASE maestro;
-```
-
-```shell
-docker run \
-  -p 8080:8080 \
-  -e CONDUCTOR_CONFIGS_JDBCURL=jdbc:postgresql://cockroachdb:26257/maestro \
-  -e CONDUCTOR_CONFIGS_JDBCUSERNAME=root \
-  maestro-server:0.1
+docker run -d -p 26257:26257 --name cockroachdb cockroachdb/cockroach:v24.1.0 start-single-node --insecure
+docker exec cockroachdb cockroach sql --insecure --execute 'CREATE DATABASE maestro;'
 ```

--- a/maestro-server/README.md
+++ b/maestro-server/README.md
@@ -1,3 +1,45 @@
-Maestro Server
+# Maestro Server
 ===================================
 This module includes a Springboot app implementation of Maestro server.
+
+## Docker
+
+### Run
+
+Assuming you have cockroachdb already setup and running ([otherwise check these steps](#cockroachdb)):
+
+```shell
+docker run \
+  -p 8080:8080 \
+  -e CONDUCTOR_CONFIGS_JDBCURL=jdbc:postgresql://cockroachdb:26257/maestro \
+  -e CONDUCTOR_CONFIGS_JDBCUSERNAME=root \
+  datacatering/maestro:0.1.0
+```
+
+### Build
+
+Build the JAR file and Docker image via:
+
+```shell
+./gradlew bootJar
+docker build -t maestro-server:0.1 .
+```
+
+#### CockroachDB
+
+Spin up cockroachdb either yourself or via [insta-infra](https://github.com/data-catering/insta-infra), with database 
+`maestro` created.
+
+```shell
+./run.sh cockroach
+./run.sh -c cockroach
+CREATE DATABASE maestro;
+```
+
+```shell
+docker run \
+  -p 8080:8080 \
+  -e CONDUCTOR_CONFIGS_JDBCURL=jdbc:postgresql://cockroachdb:26257/maestro \
+  -e CONDUCTOR_CONFIGS_JDBCUSERNAME=root \
+  maestro-server:0.1
+```

--- a/maestro-server/build.gradle
+++ b/maestro-server/build.gradle
@@ -32,6 +32,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.+'
 }
 
+bootJar {
+    layered {
+        enabled = true
+    }
+}
+
 bootRun {
     jvmArgs += ["-Djava.security.manager=allow"]
 }


### PR DESCRIPTION
# Changes

- Add in a Docker image for the maestro-server
- Build multi-platform images via GitHub Action

# Why

- Allow users to deploy and run via Docker images
- Can start Maestro without building (no dependency on Java or Gradle version)