### PR TITLE
chore: remove Joda-Time dependency from maestro-common #25

### DIFF
--- a/maestro-common/build.gradle
+++ b/maestro-common/build.gradle
@@ -4,7 +4,6 @@ dependencies {
     implementation javaxValidationDep
     implementation jacksonYamlDep
     implementation quartzDep
-    implementation jodaTimeDep
     implementation(cronutilsDep) {
         exclude group: 'org.glassfish'
     }

--- a/maestro-common/gradle.lockfile
+++ b/maestro-common/gradle.lockfile
@@ -12,7 +12,6 @@ com.mchange:mchange-commons-java:0.2.15=compileClasspath
 com.zaxxer:HikariCP-java7:2.4.13=compileClasspath
 javax.inject:javax.inject:1=compileClasspath
 javax.validation:validation-api:2.0.1.Final=compileClasspath
-joda-time:joda-time:2.10.14=compileClasspath
 org.projectlombok:lombok:1.18.34=annotationProcessor,compileClasspath
 org.quartz-scheduler:quartz:2.3.2=compileClasspath
 org.slf4j:slf4j-api:1.7.30=compileClasspath

--- a/maestro-common/src/main/java/com/netflix/maestro/models/Defaults.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/Defaults.java
@@ -19,8 +19,8 @@ import com.netflix.maestro.models.definition.TagList;
 import com.netflix.maestro.models.instance.RunPolicy;
 import com.netflix.maestro.models.instance.StepInstance;
 import com.netflix.maestro.models.parameter.ParamMode;
+import java.time.ZoneId;
 import java.util.TimeZone;
-import org.joda.time.DateTimeZone;
 
 /** Class to hold the user facing default values for unset fields. */
 public final class Defaults {
@@ -103,7 +103,7 @@ public final class Defaults {
       StepInstance.Status.NOT_CREATED;
 
   /** Default Time Zone. * */
-  public static final TimeZone DEFAULT_TIMEZONE = DateTimeZone.UTC.toTimeZone();
+  public static final TimeZone DEFAULT_TIMEZONE = TimeZone.getTimeZone(ZoneId.of("UTC"));
 
   /** Default Param Mode. */
   public static final ParamMode DEFAULT_PARAM_MODE = ParamMode.MUTABLE;

--- a/maestro-common/src/main/java/com/netflix/maestro/utils/TriggerHelper.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/utils/TriggerHelper.java
@@ -23,6 +23,7 @@ import com.netflix.maestro.models.trigger.PredefinedTimeTrigger;
 import com.netflix.maestro.models.trigger.TimeTrigger;
 import com.netflix.maestro.models.trigger.TimeTriggerWithJitter;
 import java.text.ParseException;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.Optional;
 import java.util.Random;
@@ -31,7 +32,6 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.joda.time.DateTimeZone;
 import org.quartz.CronExpression;
 
 /** Cron Helper utility class. * */
@@ -60,7 +60,7 @@ public final class TriggerHelper {
    * @throws ParseException parse error
    */
   public static CronExpression buildCron(String cron, String timezone) throws ParseException {
-    return buildCron(cron, DateTimeZone.forID(timezone).toTimeZone());
+    return buildCron(cron, TimeZone.getTimeZone(ZoneId.of(timezone)));
   }
 
   /**

--- a/maestro-common/src/main/java/com/netflix/maestro/validations/TimeZoneConstraint.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/validations/TimeZoneConstraint.java
@@ -17,11 +17,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.time.ZoneId;
+import java.util.Set;
 import javax.validation.Constraint;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
-import org.joda.time.DateTimeZone;
 
 /** Maestro timezone expression validation. */
 @Documented
@@ -40,6 +41,8 @@ public @interface TimeZoneConstraint {
 
   /** Maestro timezone validator. */
   class TimeZoneValidator implements ConstraintValidator<TimeZoneConstraint, String> {
+    private static final Set<String> AVAILABLE_ZONE_IDS = ZoneId.getAvailableZoneIds();
+
     @Override
     public void initialize(TimeZoneConstraint constraint) {}
 
@@ -49,14 +52,13 @@ public @interface TimeZoneConstraint {
         return true;
       }
 
-      try {
-        DateTimeZone.forID(timezone);
-      } catch (IllegalArgumentException e) {
+      if (!AVAILABLE_ZONE_IDS.contains(timezone)) {
         context
-            .buildConstraintViolationWithTemplate("[timezone expression] is not valid: " + e)
+            .buildConstraintViolationWithTemplate("[timezone expression] is not valid: " + timezone)
             .addConstraintViolation();
         return false;
       }
+
       return true;
     }
   }


### PR DESCRIPTION
**Pull Request type**
----
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

**Changes in this PR**
----

This pull request removes the Joda-Time dependency #25  from the `maestro-common` module and replaces it with the `java.time` API. The changes include:

- Removed Joda-Time dependency from the `Defaults` class and replaced it with `java.time.ZoneId`.
- Updated `TriggerHelper` class to use `java.time.ZoneId` instead of Joda-Time's `DateTimeZone`.
- Simplified `TimeZoneValidator` to use a static final set of available time zone IDs, ensuring efficient validation.

This change modernizes the codebase by adopting the java.time API, which is the recommended approach for handling date and time in Java 8 and later versions. The updates ensure that time zone handling is consistent and efficient
