### PR TITLE
Refactor: Update build.gradle and fix import order in SelJodaDateTimePropertyTest to pass Spotless check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
     }
 
     test {
-        jvmArgs += ["-Djava.security.manager=allow"]
+        jvmArgs += ["-Djava.security.manager=allow", "-Duser.language=en", "-Duser.country=US"]
     }
 
     configurations.configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
     }
 
     test {
-        jvmArgs += ["-Djava.security.manager=allow", "-Duser.language=en", "-Duser.country=US"]
+        jvmArgs += ["-Djava.security.manager=allow"]
     }
 
     configurations.configureEach {

--- a/netflix-sel/src/test/java/com/netflix/sel/type/SelJodaDateTimePropertyTest.java
+++ b/netflix-sel/src/test/java/com/netflix/sel/type/SelJodaDateTimePropertyTest.java
@@ -12,7 +12,7 @@
  */
 package com.netflix.sel.type;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import com.netflix.sel.visitor.SelOp;
 import org.joda.time.DateTime;


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
chore: Update build.gradle
- If the developer's computer environment is not set to English, running Unit Tests may result in errors.

fix: Correct import order to pass Spotless check in SelJodaDateTimePropertyTest
- Adjusted the order of imports to comply with Spotless formatting rules.
- Ran `./gradlew :netflix-sel:spotlessApply` to automatically fix format violations.
