### PR TITLE
Support the timeout retry policy

### DIFF
--- a/maestro-common/src/main/java/com/netflix/maestro/models/Actions.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/Actions.java
@@ -208,6 +208,9 @@ public final class Actions {
     STEP_INSTANCE_STATUS_TO_ACTION_MAP.put(
         StepInstance.Status.PLATFORM_FAILED,
         Arrays.asList(StepInstanceAction.STOP, StepInstanceAction.KILL, StepInstanceAction.SKIP));
+    STEP_INSTANCE_STATUS_TO_ACTION_MAP.put(
+        StepInstance.Status.TIMEOUT_FAILED,
+        Arrays.asList(StepInstanceAction.STOP, StepInstanceAction.KILL, StepInstanceAction.SKIP));
 
     STEP_INSTANCE_STATUS_TO_ACTION_MAP.put(
         StepInstance.Status.FATALLY_FAILED,

--- a/maestro-common/src/main/java/com/netflix/maestro/models/Constants.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/Constants.java
@@ -147,6 +147,9 @@ public final class Constants {
   /** maximum retry wait limit for platform errors. */
   public static final int MAX_PLATFORM_RETRY_LIMIT_SECS = 24 * 3600; // 1 day
 
+  /** maximum retry wait limit for timeout errors. */
+  public static final int MAX_TIMEOUT_RETRY_LIMIT_SECS = 24 * 3600; // 1 days
+
   /** Max timeout limit in milliseconds. */
   public static final long MAX_TIME_OUT_LIMIT_IN_MILLIS = TimeUnit.DAYS.toMillis(120); // 120 days
 

--- a/maestro-common/src/main/java/com/netflix/maestro/models/Defaults.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/Defaults.java
@@ -39,6 +39,9 @@ public final class Defaults {
   /** Defaults for fixed retry delay for user errors. */
   private static final long DEFAULT_FIXED_USER_RETRY_BACKOFF_SECS = 60L;
 
+  /** Defaults for fixed retry delay for timeout errors. */
+  private static final long DEFAULT_FIXED_TIMEOUT_RETRY_BACKOFF_SECS = 60L;
+
   /** Defaults for exponential retry exponent for user errors. */
   private static final int DEFAULT_ERROR_RETRY_EXPONENT = 2;
 
@@ -57,32 +60,47 @@ public final class Defaults {
   /** Defaults for exponential max retry limit for platform errors. */
   private static final long DEFAULT_PLATFORM_RETRY_LIMIT_SECS = 3600L;
 
+  /** Defaults for exponential retry exponent for timeout errors. */
+  private static final int DEFAULT_TIMEOUT_RETRY_EXPONENT = 2;
+
+  /** Defaults for exponential retry base backoff for timeout errors. */
+  private static final long DEFAULT_BASE_TIMEOUT_RETRY_BACKOFF_SECS = 60L;
+
+  /** Defaults for exponential max retry limit for timeout errors. */
+  private static final long DEFAULT_TIMEOUT_RETRY_LIMIT_SECS = 3600L;
+
   /** Default Exponential backoff. */
   public static final RetryPolicy.ExponentialBackoff DEFAULT_EXPONENTIAL_BACK_OFF =
       RetryPolicy.ExponentialBackoff.builder()
           .errorRetryExponent(DEFAULT_ERROR_RETRY_EXPONENT)
           .errorRetryBackoffInSecs(DEFAULT_BASE_ERROR_RETRY_BACKOFF_SECS)
           .errorRetryLimitInSecs(DEFAULT_ERROR_RETRY_LIMIT_SECS)
-          .platformRetryBackoffInSecs(DEFAULT_BASE_PLATFORM_RETRY_BACKOFF_SECS)
           .platformRetryExponent(DEFAULT_PLATFORM_RETRY_EXPONENT)
+          .platformRetryBackoffInSecs(DEFAULT_BASE_PLATFORM_RETRY_BACKOFF_SECS)
           .platformRetryLimitInSecs(DEFAULT_PLATFORM_RETRY_LIMIT_SECS)
+          .timeoutRetryExponent(DEFAULT_TIMEOUT_RETRY_EXPONENT)
+          .timeoutRetryBackoffInSecs(DEFAULT_BASE_TIMEOUT_RETRY_BACKOFF_SECS)
+          .timeoutRetryLimitInSecs(DEFAULT_TIMEOUT_RETRY_LIMIT_SECS)
           .build();
 
   /** Default Fixed backoff. */
   public static final RetryPolicy.FixedBackoff DEFAULT_FIXED_BACK_OFF =
       RetryPolicy.FixedBackoff.builder()
-          .platformRetryBackoffInSecs(DEFAULT_FIXED_PLATFORM_RETRY_BACKOFF_SECS)
           .errorRetryBackoffInSecs(DEFAULT_FIXED_USER_RETRY_BACKOFF_SECS)
+          .platformRetryBackoffInSecs(DEFAULT_FIXED_PLATFORM_RETRY_BACKOFF_SECS)
+          .timeoutRetryBackoffInSecs(DEFAULT_FIXED_TIMEOUT_RETRY_BACKOFF_SECS)
           .build();
 
   private static final long DEFAULT_USER_RETRY_LIMIT = 2L;
   private static final long DEFAULT_PLATFORM_RETRY_LIMIT = 10L;
+  private static final long DEFAULT_TIMEOUT_RETRY_LIMIT = 0L;
 
   /** Default retry policy if unset. */
   public static final RetryPolicy DEFAULT_RETRY_POLICY =
       RetryPolicy.builder()
           .errorRetryLimit(DEFAULT_USER_RETRY_LIMIT)
           .platformRetryLimit(DEFAULT_PLATFORM_RETRY_LIMIT)
+          .timeoutRetryLimit(DEFAULT_TIMEOUT_RETRY_LIMIT)
           .backoff(DEFAULT_EXPONENTIAL_BACK_OFF)
           .build();
 

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/utils/AggregatedViewHelper.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/utils/AggregatedViewHelper.java
@@ -81,6 +81,8 @@ public final class AggregatedViewHelper {
         StepInstance.Status.USER_FAILED, WorkflowInstance.Status.FAILED);
     STEP_INSTANCE_STATUS_TO_WORKFLOW_INSTANCE_STATUS.put(
         StepInstance.Status.PLATFORM_FAILED, WorkflowInstance.Status.FAILED);
+    STEP_INSTANCE_STATUS_TO_WORKFLOW_INSTANCE_STATUS.put(
+        StepInstance.Status.TIMEOUT_FAILED, WorkflowInstance.Status.FAILED);
 
     // STOPPED statuses
     STEP_INSTANCE_STATUS_TO_WORKFLOW_INSTANCE_STATUS.put(

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/utils/TaskHelper.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/utils/TaskHelper.java
@@ -250,7 +250,8 @@ public final class TaskHelper {
         } else if (entry.getKey() == StepInstance.Status.FATALLY_FAILED
             || entry.getKey() == StepInstance.Status.INTERNALLY_FAILED
             || entry.getKey() == StepInstance.Status.USER_FAILED
-            || entry.getKey() == StepInstance.Status.PLATFORM_FAILED) {
+            || entry.getKey() == StepInstance.Status.PLATFORM_FAILED
+            || entry.getKey() == StepInstance.Status.TIMEOUT_FAILED) {
           isFailed = true;
         } else if (entry.getKey() == StepInstance.Status.TIMED_OUT) {
           isTimeout = true;


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR

Support the timeout retry policy.

In many cases, users want to retry step when timed out, e.g. the execution is unexpected to be stuck due to platform issues.
