### PR TITLE
Add two SEL functions to support getting a specific param from a subworkflow and getting a step's end time.

### DIFF
--- a/maestro-common/src/main/java/com/netflix/maestro/models/Constants.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/Constants.java
@@ -262,6 +262,9 @@ public final class Constants {
   /** Step instance status param name key used in SEL to retrieve the step status. */
   public static final String STEP_STATUS_PARAM = "MAESTRO_STEP_STATUS";
 
+  /** Step instance end time param name key used in SEL to retrieve the step end time. */
+  public static final String STEP_END_TIME_PARAM = "MAESTRO_STEP_END_TIME";
+
   /**
    * Match all instances. Special value to denote a breakpoint which is set to match all wf
    * instances.

--- a/maestro-common/src/testFixtures/resources/fixtures/execution/sample-step-runtime-summary-3.json
+++ b/maestro-common/src/testFixtures/resources/fixtures/execution/sample-step-runtime-summary-3.json
@@ -4,7 +4,7 @@
   "step_instance_id": 123,
   "step_attempt_id": 2,
   "step_instance_uuid": "bar",
-  "type": "subworkflow",
+  "type": "foreach",
   "step_run_params": {
     "foo": {
       "value": "bar",
@@ -46,19 +46,19 @@
       "value": 1,
       "foo": "bar"
     },
-    "maestro_subworkflow": {
-      "subworkflow_id": "test-dag",
-      "subworkflow_version_id": 1,
-      "subworkflow_instance_id": 1,
-      "subworkflow_run_id": 1,
-      "subworkflow_uuid": "foo-bar",
-      "subworkflow_overview": {
-        "step_overview": {
+    "maestro_foreach": {
+      "foreach_workflow_id": "inline-wf",
+      "foreach_identity": "foo",
+      "total_loop_count": 10,
+      "next_loop_index": 0,
+      "foreach_overview": {
+        "checkpoint": 6,
+        "stats": {
+          "CREATED": 5,
           "SUCCEEDED": 1
-        },
-        "total_step_count": 1
+        }
       },
-      "type": "SUBWORKFLOW"
+      "type": "FOREACH"
     }
   },
   "dependencies": {

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/execution/StepRuntimeSummaryTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/execution/StepRuntimeSummaryTest.java
@@ -211,7 +211,7 @@ public class StepRuntimeSummaryTest extends MaestroEngineBaseTest {
   public void testMergeForeachArtifact() throws Exception {
     StepRuntimeSummary summary =
         loadObject(
-            "fixtures/execution/sample-step-runtime-summary-1.json", StepRuntimeSummary.class);
+            "fixtures/execution/sample-step-runtime-summary-3.json", StepRuntimeSummary.class);
     ForeachArtifact artifact = summary.getArtifacts().get(Artifact.Type.FOREACH.key()).asForeach();
     assertEquals("inline-wf", artifact.getForeachWorkflowId());
     assertEquals("foo", artifact.getForeachIdentity());
@@ -427,6 +427,10 @@ public class StepRuntimeSummaryTest extends MaestroEngineBaseTest {
     summary.mergeRuntimeUpdate(null, artifacts);
     assertTrue(summary.isSynced());
 
+    summary =
+        loadObject(
+            "fixtures/execution/sample-step-runtime-summary-3.json", StepRuntimeSummary.class);
+    artifacts.clear();
     ForeachArtifact artifact3 = new ForeachArtifact();
     artifact3.setForeachWorkflowId("inline-wf");
     artifact3.setForeachIdentity("foo");


### PR DESCRIPTION
Add two SEL functions to support getting a specific param from a subworkflow and getting a step's end time.

Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR

Add two SEL functions to support getting a specific param from a subworkflow and getting a step's end time.
