### PR TITLE
Fix the way to retrieve the step attempt in two places:

### DIFF
--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/MaestroParamExtension.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/MaestroParamExtension.java
@@ -438,12 +438,8 @@ public class MaestroParamExtension extends AbstractParamExtension {
             .asSubworkflow();
 
     StepInstance stepInstance =
-        stepInstanceDao.getStepInstance(
-            artifact.getSubworkflowId(),
-            artifact.getSubworkflowInstanceId(),
-            artifact.getSubworkflowRunId(),
-            stepId,
-            Constants.LATEST_INSTANCE_RUN);
+        stepInstanceDao.getStepInstanceView(
+            artifact.getSubworkflowId(), artifact.getSubworkflowInstanceId(), stepId);
 
     if (stepInstance.getParams() == null || !stepInstance.getParams().containsKey(paramName)) {
       throw new MaestroInvalidExpressionException("Cannot find the param name: [%s]", paramName);

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/processors/InstanceActionJobEventProcessor.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/processors/InstanceActionJobEventProcessor.java
@@ -18,6 +18,7 @@ import com.netflix.maestro.exceptions.MaestroRetryableError;
 import com.netflix.maestro.exceptions.MaestroRuntimeException;
 import com.netflix.maestro.flow.runtime.FlowOperation;
 import com.netflix.maestro.models.Actions;
+import com.netflix.maestro.models.Constants;
 import com.netflix.maestro.models.instance.StepInstance;
 import com.netflix.maestro.models.instance.WorkflowInstance;
 import com.netflix.maestro.queue.jobevents.InstanceActionJobEvent;
@@ -116,7 +117,7 @@ public class InstanceActionJobEventProcessor
             jobEvent.getWorkflowInstanceId(),
             jobEvent.getWorkflowRunId(),
             jobEvent.getStepId(),
-            jobEvent.getStepAttemptId());
+            Constants.LATEST_INSTANCE_RUN);
     if (stepInstance == null) {
       LOG.warn(
           "Action is requested on an invalid step instance. The requested action is: {}",

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/eval/MaestroParamExtensionTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/eval/MaestroParamExtensionTest.java
@@ -161,7 +161,7 @@ public class MaestroParamExtensionTest extends MaestroEngineBaseTest {
     when(allStepOutputData.get("foo"))
         .thenReturn(Collections.singletonMap("maestro_step_runtime_summary", summary));
     StepInstance stepInSubworkflow = loadObject(TEST_STEP_INSTANCE, StepInstance.class);
-    when(stepInstanceDao.getStepInstance(any(), anyLong(), anyLong(), any(), any()))
+    when(stepInstanceDao.getStepInstanceView(any(), anyLong(), any()))
         .thenReturn(stepInSubworkflow);
     long res = (Long) paramExtension.getFromSubworkflow("foo", "job1", "sleep_seconds");
     assertEquals(15, res);

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/processors/InstanceActionJobEventProcessorTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/processors/InstanceActionJobEventProcessorTest.java
@@ -23,6 +23,7 @@ import com.netflix.maestro.engine.dao.MaestroWorkflowInstanceDao;
 import com.netflix.maestro.exceptions.MaestroRetryableError;
 import com.netflix.maestro.flow.runtime.FlowOperation;
 import com.netflix.maestro.models.Actions;
+import com.netflix.maestro.models.Constants;
 import com.netflix.maestro.models.artifact.Artifact;
 import com.netflix.maestro.models.definition.Step;
 import com.netflix.maestro.models.definition.StepType;
@@ -53,7 +54,7 @@ public class InstanceActionJobEventProcessorTest extends MaestroEngineBaseTest {
   private final String workflowId = "sample-test-workflow-id";
   private final long workflowInstanceId = 2;
   private final long workflowRunId = 3;
-  private final String stepAttemptId = "2";
+  private final String stepAttemptId = Constants.LATEST_INSTANCE_RUN;
   private final long groupInfo = 12L;
   private final String stepId = "sample-test-step-id";
   private InstanceActionJobEventProcessor processor;
@@ -97,7 +98,7 @@ public class InstanceActionJobEventProcessorTest extends MaestroEngineBaseTest {
     when(stepInstance.getArtifacts()).thenReturn(artifactMap);
     when(stepInstance.getStepId()).thenReturn(stepId);
     when(stepInstance.getGroupInfo()).thenReturn(groupInfo);
-    when(stepInstance.getStepAttemptId()).thenReturn(Long.valueOf(stepAttemptId));
+    when(stepInstance.getStepAttemptId()).thenReturn(2L);
     when(foreachStepInstance.getGroupInfo()).thenReturn(groupInfo);
   }
 


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Fix the way to retrieve the step attempt in two places:
1. As the action is on the step in a run, should check the status of the latest step status.
2. getFromSubworkflow should retrieve the data of the latest step attempt.
