### PR TITLE
Explicitly clear the pending action after passing it to the step runtime.

### DIFF
--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/execution/StepRuntimeManager.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/execution/StepRuntimeManager.java
@@ -61,6 +61,7 @@ public final class StepRuntimeManager {
     StepAction latestAction = summary.getPendingAction();
     StepRuntimeSummary cloned = objectMapper.convertValue(summary, StepRuntimeSummary.class);
     cloned.setPendingAction(latestAction);
+    summary.setPendingAction(null); // clear the pending action after passing it to step runtime
     return cloned;
   }
 

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/execution/StepRuntimeManagerTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/execution/StepRuntimeManagerTest.java
@@ -15,10 +15,12 @@ package com.netflix.maestro.engine.execution;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.netflix.maestro.engine.MaestroEngineBaseTest;
+import com.netflix.maestro.engine.db.StepAction;
 import com.netflix.maestro.engine.params.DefaultParamManager;
 import com.netflix.maestro.engine.params.ParamsManager;
 import com.netflix.maestro.engine.steps.StepRuntime;
@@ -138,6 +140,8 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
             .type(StepType.NOOP)
             .stepRetry(StepInstance.StepRetry.from(Defaults.DEFAULT_RETRY_POLICY))
             .build();
+    summary.setPendingAction(StepAction.builder().build());
+    assertNotNull(summary.getPendingAction());
     boolean ret = runtimeManager.start(workflowSummary, null, summary);
     assertTrue(ret);
     assertEquals(StepInstance.Status.RUNNING, summary.getRuntimeState().getStatus());
@@ -149,6 +153,7 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
     assertEquals(StepInstance.Status.RUNNING, summary.getPendingRecords().get(0).getNewStatus());
     assertEquals(artifact, summary.getArtifacts().get("test-artifact"));
     assertTrue(summary.getTimeline().isEmpty());
+    assertNull(summary.getPendingAction());
   }
 
   @Test
@@ -193,6 +198,8 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
             .type(StepType.NOOP)
             .stepRetry(StepInstance.StepRetry.from(Defaults.DEFAULT_RETRY_POLICY))
             .build();
+    summary.setPendingAction(StepAction.builder().build());
+    assertNotNull(summary.getPendingAction());
     boolean ret = runtimeManager.execute(workflowSummary, null, summary);
     assertTrue(ret);
     assertEquals(StepInstance.Status.FINISHING, summary.getRuntimeState().getStatus());
@@ -204,6 +211,7 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
     assertEquals(StepInstance.Status.FINISHING, summary.getPendingRecords().get(0).getNewStatus());
     assertEquals(artifact, summary.getArtifacts().get("test-artifact"));
     assertTrue(summary.getTimeline().isEmpty());
+    assertNull(summary.getPendingAction());
   }
 
   @Test
@@ -248,6 +256,8 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
             .type(StepType.NOOP)
             .stepRetry(StepInstance.StepRetry.from(Defaults.DEFAULT_RETRY_POLICY))
             .build();
+    summary.setPendingAction(StepAction.builder().build());
+    assertNotNull(summary.getPendingAction());
     runtimeManager.terminate(workflowSummary, summary, StepInstance.Status.STOPPED);
     assertEquals(StepInstance.Status.STOPPED, summary.getRuntimeState().getStatus());
     assertNotNull(summary.getRuntimeState().getEndTime());
@@ -259,6 +269,7 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
     assertEquals(artifact, summary.getArtifacts().get("test-artifact"));
     assertEquals(1, summary.getTimeline().getTimelineEvents().size());
     assertEquals("test termination", summary.getTimeline().getTimelineEvents().get(0).getMessage());
+    assertNull(summary.getPendingAction());
   }
 
   @Test

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/execution/StepRuntimeManagerTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/execution/StepRuntimeManagerTest.java
@@ -149,10 +149,12 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
     assertNotNull(summary.getRuntimeState().getModifyTime());
     assertEquals(1, summary.getPendingRecords().size());
     assertEquals(
-        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().get(0).getOldStatus());
-    assertEquals(StepInstance.Status.RUNNING, summary.getPendingRecords().get(0).getNewStatus());
+        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().getFirst().getOldStatus());
+    assertEquals(
+        StepInstance.Status.RUNNING, summary.getPendingRecords().getFirst().getNewStatus());
     assertEquals(artifact, summary.getArtifacts().get("test-artifact"));
     assertTrue(summary.getTimeline().isEmpty());
+    // The pending action should have been cleared after passing it to step runtime
     assertNull(summary.getPendingAction());
   }
 
@@ -172,9 +174,9 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
     assertNotNull(summary.getRuntimeState().getModifyTime());
     assertEquals(1, summary.getPendingRecords().size());
     assertEquals(
-        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().get(0).getOldStatus());
+        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().getFirst().getOldStatus());
     assertEquals(
-        StepInstance.Status.USER_FAILED, summary.getPendingRecords().get(0).getNewStatus());
+        StepInstance.Status.USER_FAILED, summary.getPendingRecords().getFirst().getNewStatus());
     assertTrue(summary.getArtifacts().isEmpty());
 
     stepRetry.incrementByStatus(StepInstance.Status.USER_FAILED);
@@ -207,10 +209,12 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
     assertNotNull(summary.getRuntimeState().getModifyTime());
     assertEquals(1, summary.getPendingRecords().size());
     assertEquals(
-        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().get(0).getOldStatus());
-    assertEquals(StepInstance.Status.FINISHING, summary.getPendingRecords().get(0).getNewStatus());
+        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().getFirst().getOldStatus());
+    assertEquals(
+        StepInstance.Status.FINISHING, summary.getPendingRecords().getFirst().getNewStatus());
     assertEquals(artifact, summary.getArtifacts().get("test-artifact"));
     assertTrue(summary.getTimeline().isEmpty());
+    // The pending action should have been cleared after passing it to step runtime
     assertNull(summary.getPendingAction());
   }
 
@@ -230,9 +234,9 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
     assertNotNull(summary.getRuntimeState().getModifyTime());
     assertEquals(1, summary.getPendingRecords().size());
     assertEquals(
-        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().get(0).getOldStatus());
+        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().getFirst().getOldStatus());
     assertEquals(
-        StepInstance.Status.PLATFORM_FAILED, summary.getPendingRecords().get(0).getNewStatus());
+        StepInstance.Status.PLATFORM_FAILED, summary.getPendingRecords().getFirst().getNewStatus());
     assertTrue(summary.getArtifacts().isEmpty());
 
     stepRetry.incrementByStatus(StepInstance.Status.PLATFORM_FAILED);
@@ -264,11 +268,14 @@ public class StepRuntimeManagerTest extends MaestroEngineBaseTest {
     assertNotNull(summary.getRuntimeState().getModifyTime());
     assertEquals(1, summary.getPendingRecords().size());
     assertEquals(
-        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().get(0).getOldStatus());
-    assertEquals(StepInstance.Status.STOPPED, summary.getPendingRecords().get(0).getNewStatus());
+        StepInstance.Status.NOT_CREATED, summary.getPendingRecords().getFirst().getOldStatus());
+    assertEquals(
+        StepInstance.Status.STOPPED, summary.getPendingRecords().getFirst().getNewStatus());
     assertEquals(artifact, summary.getArtifacts().get("test-artifact"));
     assertEquals(1, summary.getTimeline().getTimelineEvents().size());
-    assertEquals("test termination", summary.getTimeline().getTimelineEvents().get(0).getMessage());
+    assertEquals(
+        "test termination", summary.getTimeline().getTimelineEvents().getFirst().getMessage());
+    // The pending action should have been cleared after passing it to step runtime
     assertNull(summary.getPendingAction());
   }
 

--- a/maestro-server/src/main/resources/application-aws.yml
+++ b/maestro-server/src/main/resources/application-aws.yml
@@ -16,7 +16,7 @@ server:
   port: 8080
 
 maestro:
-  queue:
+  queue: # check MaestroJobEvent class for queue id
     properties:
       1:
         worker-num: 8
@@ -32,7 +32,8 @@ maestro:
         scan-interval: 5000
       5:
         worker-num: 3
-        scan-interval: 10000
+        scan-interval: 30000
+        ownership-timeout: 125000 # larger than the deletion processor timeout
   notifier:
     type: sns
   alerting:

--- a/maestro-server/src/main/resources/application.yml
+++ b/maestro-server/src/main/resources/application.yml
@@ -11,7 +11,7 @@ server:
   port: 8080
 
 maestro:
-  queue:
+  queue: # check MaestroJobEvent class for queue id
     properties:
       1:
         worker-num: 8


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Explicitly clear the pending action after passing it to the step runtime.

In old engine, it relies on @JsonIgnore to clear the pending action in each polling cycle. In the new engine, the state is kept in memory and so we need to explicitly clear the pending action after passing it to the step runtime.
