### PR TITLE
Fix edge case where unblocking workflow doesn't enqueue job event

### DIFF
--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroWorkflowInstanceDao.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroWorkflowInstanceDao.java
@@ -596,7 +596,7 @@ public class MaestroWorkflowInstanceDao extends AbstractDatabaseDao {
                           stmt.setString(++idx, workflowId);
                           stmt.setInt(++idx, batchLimit);
                           int res = stmt.executeUpdate();
-                          if (res < batchLimit && totalUnblocked[0] > 0) {
+                          if (res < batchLimit && totalUnblocked[0] + res > 0) {
                             message[0] = queueSystem.enqueue(conn, jobEvent);
                           }
                           return res;

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroWorkflowInstanceDaoTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroWorkflowInstanceDaoTest.java
@@ -752,8 +752,9 @@ public class MaestroWorkflowInstanceDaoTest extends MaestroDaoBaseTest {
     verify(queueSystem, times(2)).enqueue(any(), any());
     verify(queueSystem, times(2)).notify(any());
 
-    // we have 2 failed instances and batch size = 10, this is to test all failed instances are
-    // unblocked in first loop and DB returned count < batch size.
+    // Tests the scenario where two instances have failed, and we attempt to unblock them with a
+    // batch size of 10. Since all failed instances are unblocked in the first iteration, the
+    // database returns a count smaller than the batch size.
     int ret = instanceDao.tryUnblockFailedWorkflowInstances(TEST_WORKFLOW_ID, 10, null);
     assertEquals(2, ret);
     status = instanceDao.getWorkflowInstanceRawStatus(TEST_WORKFLOW_ID, 1L, 1L);


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
There is an edge case when we unblock all failed instances in batches and default batch size = 100, the only failed instance was unblocked in first while loop but didn't enqueue a job event because the condition requires unblocked count > 0 (in 1st loop this value is not updated and is still 0). This PR updated the if condition to account for this case.
