### PR TITLE
Check if string map param is literal before returning the value.

### DIFF
--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/params/ParamsMergeHelper.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/params/ParamsMergeHelper.java
@@ -696,6 +696,11 @@ public final class ParamsMergeHelper {
             "ParameterDefinition type mismatch, [%s] is not a [STRING_MAP] but [%s]",
             key, paramDef.getType().toString());
       }
+      Checks.checkTrue(
+          paramDef.isLiteral(),
+          "param [%s] definition exp=[%s] is not a literal",
+          key,
+          paramDef.getExpression());
       return paramDef.asStringMapParamDef().getValue();
     } else {
       return new LinkedHashMap<>();

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/params/ParamsMergeHelperTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/params/ParamsMergeHelperTest.java
@@ -84,14 +84,13 @@ public class ParamsMergeHelperTest extends MaestroEngineBaseTest {
 
   private Map<String, ParamDefinition> parseParamDefMap(String json)
       throws JsonProcessingException {
-    TypeReference<Map<String, ParamDefinition>> paramDefMap =
-        new TypeReference<Map<String, ParamDefinition>>() {};
-    return MAPPER.readValue(json.replaceAll("\'", "\""), paramDefMap);
+    TypeReference<Map<String, ParamDefinition>> paramDefMap = new TypeReference<>() {};
+    return MAPPER.readValue(json.replaceAll("'", "\""), paramDefMap);
   }
 
   private Map<String, Parameter> parseParamMap(String json) throws JsonProcessingException {
-    TypeReference<Map<String, Parameter>> paramMap = new TypeReference<Map<String, Parameter>>() {};
-    return MAPPER.readValue(json.replaceAll("\'", "\""), paramMap);
+    TypeReference<Map<String, Parameter>> paramMap = new TypeReference<>() {};
+    return MAPPER.readValue(json.replaceAll("'", "\""), paramMap);
   }
 
   @Test
@@ -209,6 +208,15 @@ public class ParamsMergeHelperTest extends MaestroEngineBaseTest {
     assertEquals(
         "data = new HashMap(); data.put(\"foo\", \"bat\"); return data;",
         allParams.get("tomerge").asStringMapParamDef().getExpression());
+
+    // paramsToMerge is a literal and mergeParams should throw an error
+    Map<String, ParamDefinition> valParamsToMerge =
+        parseParamDefMap("{'tomerge': {'type': 'STRING_MAP','value': {}}}");
+    AssertHelper.assertThrows(
+        "Should not allow merging string map param to a SEL defined param",
+        IllegalArgumentException.class,
+        "param [tomerge] definition exp=[data = new HashMap(); data.put(\"foo\", \"bat\"); return data;] is not a literal",
+        () -> ParamsMergeHelper.mergeParams(allParams, valParamsToMerge, definitionContext));
   }
 
   @Test
@@ -389,8 +397,7 @@ public class ParamsMergeHelperTest extends MaestroEngineBaseTest {
       Map<String, ParamDefinition> allParams =
           parseParamDefMap(
               String.format(
-                  "{'tomerge': {'type': 'STRING','value': 'hello', 'mode': '%s'}}",
-                  mode.toString()));
+                  "{'tomerge': {'type': 'STRING','value': 'hello', 'mode': '%s'}}", mode));
       Map<String, ParamDefinition> paramsToMerge =
           parseParamDefMap("{'tomerge': {'type': 'STRING', 'value': 'goodbye'}}");
       ParamsMergeHelper.mergeParams(allParams, paramsToMerge, systemMergeContext);
@@ -404,8 +411,7 @@ public class ParamsMergeHelperTest extends MaestroEngineBaseTest {
       Map<String, ParamDefinition> allParams =
           parseParamDefMap(
               String.format(
-                  "{'tomerge': {'type': 'STRING','value': 'hello', 'mode': '%s'}}",
-                  mode.toString()));
+                  "{'tomerge': {'type': 'STRING','value': 'hello', 'mode': '%s'}}", mode));
       Map<String, ParamDefinition> paramsToMerge =
           parseParamDefMap(
               "{'tomerge': {'type': 'STRING', 'value': 'goodbye', 'source': 'SYSTEM_INJECTED'}}");
@@ -419,8 +425,7 @@ public class ParamsMergeHelperTest extends MaestroEngineBaseTest {
       Map<String, ParamDefinition> allParams =
           parseParamDefMap(
               String.format(
-                  "{'tomerge': {'type': 'STRING','value': 'hello', 'mode': '%s'}}",
-                  mode.toString()));
+                  "{'tomerge': {'type': 'STRING','value': 'hello', 'mode': '%s'}}", mode));
       Map<String, ParamDefinition> paramsToMergeNoSource =
           parseParamDefMap("{'tomerge': {'type': 'STRING', 'value': 'goodbye'}}");
       AssertHelper.assertThrows(


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [x] Other (please describe): improve the param merges

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
Check if string map param is literal before turning the value.
