### PR TITLE
Maestro workers should not retry in certain cases

### DIFF
--- a/maestro-queue/src/main/java/com/netflix/maestro/queue/metrics/MetricConstants.java
+++ b/maestro-queue/src/main/java/com/netflix/maestro/queue/metrics/MetricConstants.java
@@ -27,8 +27,8 @@ public final class MetricConstants extends com.netflix.maestro.metrics.MetricCon
   /** Metric to record the queueing delay time for a worker queue. */
   public static final String WORKER_QUEUE_QUEUEING_DELAY = "maestro.worker.queue.queueing.delay";
 
-  /** Metric to count for the queue worker internal error. */
-  public static final String QUEUE_WORKER_INTERNAL_ERROR = "maestro.queue.worker.internal.error";
+  /** Metric to count for the queue worker process error. */
+  public static final String QUEUE_WORKER_PROCESS_ERROR = "maestro.queue.worker.process.error";
 
   /** Metric to count for the queue system enqueue transaction. */
   public static final String QUEUE_SYSTEM_ENQUEUE_TRANSACTION =


### PR DESCRIPTION
While a worker processes a job, the business logic might throw MaestroNotFoundException, e.g. the workflow is deleted. The worker should not retry in this case.

Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

While a worker processes a job, the business logic might throw MaestroNotFoundException, e.g. the workflow is deleted. The worker should not retry in this case.
