### PR TITLE
Fix an issue for workflow timeout action

### DIFF
--- a/maestro-common/src/main/java/com/netflix/maestro/models/Actions.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/Actions.java
@@ -42,7 +42,7 @@ public final class Actions {
     ACTIVATE,
     /** Deactivate a workflow. */
     DEACTIVATE,
-    /** action to flag all failed instances to unblock strict sequential. */
+    /** Action to flag all failed instances to unblock strict sequential. */
     UNBLOCK,
     /** todo support action to pause a workflow. */
     PAUSE,
@@ -53,18 +53,18 @@ public final class Actions {
   /** Supported workflow instance actions. */
   @Getter
   public enum WorkflowInstanceAction {
-    /** stop a workflow instance run and stop all its non-terminal steps. */
+    /** Stop a workflow instance run and stop all its non-terminal steps. */
     STOP(WorkflowInstance.Status.STOPPED),
-    /** kill a workflow instance run and kill all its non-terminal steps. */
+    /** Kill a workflow instance run and kill all its non-terminal steps. */
     KILL(WorkflowInstance.Status.FAILED),
-    /** restart a workflow instance. */
+    /** Restart a workflow instance. */
     RESTART(WorkflowInstance.Status.CREATED),
-    /** action to flag failed instance to unblock strict sequential. */
+    /** Action to flag failed instance to unblock strict sequential. */
     UNBLOCK(WorkflowInstance.Status.IN_PROGRESS);
 
     @JsonIgnore private final WorkflowInstance.Status status;
 
-    /** the status after the action. */
+    /** The status after the action. */
     WorkflowInstanceAction(WorkflowInstance.Status status) {
       this.status = status;
     }
@@ -88,19 +88,24 @@ public final class Actions {
     /** Bypass dependencies. */
     BYPASS_STEP_DEPENDENCIES(StepInstance.Status.EVALUATING_PARAMS, false),
     /**
-     * stop a step instance. Maestro will not stop the whole workflow instance if other steps are
+     * Stop a step instance. Maestro will not stop the whole workflow instance if other steps are
      * running.
      */
     STOP(StepInstance.Status.STOPPED, true),
     /**
-     * fail a step instance. Maestro will decide to fail the workflow or just this step by checking
+     * Internal action to time out a step instance. The action might from the upstream workflow or
+     * step instance.
+     */
+    TIME_OUT(StepInstance.Status.TIMED_OUT, true),
+    /**
+     * Fail a step instance. Maestro will decide to fail the workflow or just this step by checking
      * the step failure mode.
      */
     KILL(StepInstance.Status.FATALLY_FAILED, true),
-    /** skip a step instance and then continue dag execution to the next step. */
+    /** Skip a step instance and then continue dag execution to the next step. */
     SKIP(StepInstance.Status.SKIPPED, true),
     /**
-     * restart a failed or stopped step instance. If the workflow is running, it creates a new step
+     * Restart a failed or stopped step instance. If the workflow is running, it creates a new step
      * attempt. Otherwise, it creates a new workflow run to execute this step.
      */
     RESTART(StepInstance.Status.CREATED, false);

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/tasks/MaestroTask.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/tasks/MaestroTask.java
@@ -629,6 +629,7 @@ public final class MaestroTask implements FlowTask {
               runtimeSummary.configIgnoreFailureMode(action, workflowSummary);
               // fall through
             case STOP: // mark the step stopped, kill job
+            case TIME_OUT: // mark the step timed out, kill job
             case SKIP: // mark the step skipped, terminate job and then continue with next step
               if (status != StepInstance.Status.NOT_CREATED) {
                 // might throw retryable error if it is still terminating.
@@ -1124,8 +1125,8 @@ public final class MaestroTask implements FlowTask {
               workflowSummary,
               runtimeSummary.getStepId(),
               MAESTRO_TASK_USER,
-              Actions.StepInstanceAction.STOP,
-              "step is stopped due to timeout");
+              Actions.StepInstanceAction.TIME_OUT,
+              "step is timed out by either step or workflow timeout");
         }
         stepRuntimeManager.terminate(workflowSummary, runtimeSummary, toStatus);
       }


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Fix an issue for workflow timeout action: when the workflow is timed out, both the workflow instance and its steps should be marked as timeout.
