### PR TITLE
Improve actors to cancel the scheduled task ping action during activate/wakeup

### DIFF
--- a/maestro-flow/src/main/java/com/netflix/maestro/flow/actor/BaseActor.java
+++ b/maestro-flow/src/main/java/com/netflix/maestro/flow/actor/BaseActor.java
@@ -184,7 +184,7 @@ abstract sealed class BaseActor implements Actor permits GroupActor, FlowActor, 
       getLogger()
           .debug(
               "enqueue an action [{}] for [{}] with a delay [{}]ms", action, name(), delayInMillis);
-      var future = context.schedule(() -> actions.offer(action), delayInMillis);
+      var future = context.schedule(() -> post(action), delayInMillis);
       scheduledActions.put(action, future);
     }
   }

--- a/maestro-flow/src/main/java/com/netflix/maestro/flow/actor/TaskActor.java
+++ b/maestro-flow/src/main/java/com/netflix/maestro/flow/actor/TaskActor.java
@@ -87,6 +87,11 @@ final class TaskActor extends BaseActor {
     if (!task.isActive()) {
       task.setActive(true);
     }
+    // cancel any existing scheduled task ping as activate will schedule a new ping.
+    var future = getScheduledActions().get(new Action.TaskPing(code));
+    if (future != null) {
+      future.cancel(false);
+    }
     execute(code);
   }
 

--- a/maestro-flow/src/main/java/com/netflix/maestro/flow/actor/TaskActor.java
+++ b/maestro-flow/src/main/java/com/netflix/maestro/flow/actor/TaskActor.java
@@ -87,8 +87,10 @@ final class TaskActor extends BaseActor {
     if (!task.isActive()) {
       task.setActive(true);
     }
-    // cancel any existing scheduled task ping as activate will schedule a new ping.
-    var future = getScheduledActions().get(new Action.TaskPing(code));
+    // cancel any existing scheduled task ping as the activate call does the same action.
+    var dedupAction =
+        code == Constants.TASK_PING_CODE ? Action.TASK_PING : new Action.TaskPing(code);
+    var future = getScheduledActions().get(dedupAction);
     if (future != null) {
       future.cancel(false);
     }

--- a/maestro-flow/src/test/java/com/netflix/maestro/flow/actor/TaskActorTest.java
+++ b/maestro-flow/src/test/java/com/netflix/maestro/flow/actor/TaskActorTest.java
@@ -25,8 +25,10 @@ import com.netflix.maestro.flow.models.Flow;
 import com.netflix.maestro.flow.models.Task;
 import com.netflix.maestro.flow.models.TaskDef;
 import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class TaskActorTest extends ActorBaseTest {
 
@@ -144,7 +146,10 @@ public class TaskActorTest extends ActorBaseTest {
 
   @Test
   public void testRunForActionTaskActivate() {
+    var mockFuture = Mockito.mock(ScheduledFuture.class);
+    taskActor.getScheduledActions().put(Action.TASK_PING, mockFuture);
     verifyExecute(Action.TASK_ACTIVATE, false);
+    verify(mockFuture, times(1)).cancel(false);
   }
 
   private void verifyExecute(Action action, boolean activeFlag) {


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [x] Other (please describe): optimize activate action handling in task actor 

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Actor improvement: during activate call, cancel any existing scheduled task ping as activate will schedule a new ping.

This optimization helps as the scheduled task with the same code does the same thing as the activate. At the end of the execute(), it will schedule another task ping. So we can cancel the scheduled one. If we don't cancel it, the existing scheduled one might prevent the new action to be scheduled due to dedup logic.
