### PR TITLE
Make step param separator configurable to allow __ in step IDs and param names

### DIFF
--- a/maestro-common/src/main/java/com/netflix/maestro/models/Constants.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/Constants.java
@@ -213,6 +213,12 @@ public final class Constants {
   /** Metadata key for internal parameter mode. */
   public static final String METADATA_INTERNAL_PARAM_MODE = "internal_mode";
 
+  /**
+   * Default step parameter separator used in cross-step parameter references (e.g. {@code
+   * step1__param}). Configurable via {@code maestro.param-evaluator.step-param-separator}.
+   */
+  public static final String DEFAULT_STEP_PARAM_SEPARATOR = "__";
+
   /** Step ID Param Key. */
   public static final String STEP_ID_PARAM = "step_id";
 

--- a/maestro-common/src/main/java/com/netflix/maestro/utils/StepParamSeparator.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/utils/StepParamSeparator.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.maestro.utils;
+
+/** Interface for providing the configured step parameter separator string. */
+@FunctionalInterface
+public interface StepParamSeparator {
+
+  /** Returns the separator used in cross-step parameter references (e.g. {@code step1__param}). */
+  String getStepParamSeparator();
+}

--- a/maestro-common/src/main/java/com/netflix/maestro/validations/MaestroReferenceIdConstraint.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/validations/MaestroReferenceIdConstraint.java
@@ -12,7 +12,10 @@
  */
 package com.netflix.maestro.validations;
 
+import com.netflix.maestro.annotations.VisibleForTesting;
 import com.netflix.maestro.models.Constants;
+import com.netflix.maestro.utils.StepParamSeparator;
+import jakarta.inject.Inject;
 import jakarta.validation.Constraint;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
@@ -44,9 +47,23 @@ public @interface MaestroReferenceIdConstraint {
   class MaestroIdValidator implements ConstraintValidator<MaestroReferenceIdConstraint, String> {
     private static final Pattern ID_PATTERN = Pattern.compile("[_a-zA-Z][.\\-_a-zA-Z0-9]*+");
     private static final String REJECTED_VALUE = "- rejected value is [%s]";
+    private static final String DEFAULT_STEP_PARAM_SEPARATOR = "__";
+
+    @Inject private StepParamSeparator stepParamSeparator;
+
+    @VisibleForTesting
+    void setStepParamSeparator(StepParamSeparator stepParamSeparator) {
+      this.stepParamSeparator = stepParamSeparator;
+    }
 
     @Override
     public void initialize(MaestroReferenceIdConstraint constraint) {}
+
+    private String getSeparator() {
+      return stepParamSeparator != null
+          ? stepParamSeparator.getStepParamSeparator()
+          : DEFAULT_STEP_PARAM_SEPARATOR;
+    }
 
     @Override
     public boolean isValid(String id, ConstraintValidatorContext context) {
@@ -81,12 +98,13 @@ public @interface MaestroReferenceIdConstraint {
         return false;
       }
 
-      if (id.contains("__")) {
+      if (id.contains(getSeparator())) {
         context
             .buildConstraintViolationWithTemplate(
                 String.format(
-                    "[maestro id or name reference] cannot contain double underscores '__' "
+                    "[maestro id or name reference] cannot contain the step param separator '%s' "
                         + REJECTED_VALUE,
+                    getSeparator(),
                     id))
             .addConstraintViolation();
         return false;

--- a/maestro-common/src/main/java/com/netflix/maestro/validations/MaestroReferenceIdConstraint.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/validations/MaestroReferenceIdConstraint.java
@@ -47,7 +47,6 @@ public @interface MaestroReferenceIdConstraint {
   class MaestroIdValidator implements ConstraintValidator<MaestroReferenceIdConstraint, String> {
     private static final Pattern ID_PATTERN = Pattern.compile("[_a-zA-Z][.\\-_a-zA-Z0-9]*+");
     private static final String REJECTED_VALUE = "- rejected value is [%s]";
-    private static final String DEFAULT_STEP_PARAM_SEPARATOR = "__";
 
     @Inject private StepParamSeparator stepParamSeparator;
 
@@ -62,7 +61,7 @@ public @interface MaestroReferenceIdConstraint {
     private String getSeparator() {
       return stepParamSeparator != null
           ? stepParamSeparator.getStepParamSeparator()
-          : DEFAULT_STEP_PARAM_SEPARATOR;
+          : Constants.DEFAULT_STEP_PARAM_SEPARATOR;
     }
 
     @Override

--- a/maestro-common/src/test/java/com/netflix/maestro/validations/MaestroReferenceIdConstraintTest.java
+++ b/maestro-common/src/test/java/com/netflix/maestro/validations/MaestroReferenceIdConstraintTest.java
@@ -16,9 +16,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import com.netflix.maestro.models.Constants;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorFactory;
 import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import org.apache.bval.jsr.ApacheValidationProvider;
 import org.junit.Test;
 
 public class MaestroReferenceIdConstraintTest extends BaseConstraintTest {
@@ -99,8 +104,53 @@ public class MaestroReferenceIdConstraintTest extends BaseConstraintTest {
     ConstraintViolation<TestId> violation = violations.iterator().next();
     assertEquals("foo__bar", violation.getInvalidValue());
     assertEquals(
-        "[maestro id or name reference] cannot contain double underscores '__' - rejected value is [foo__bar]",
+        "[maestro id or name reference] cannot contain the step param separator '__' - rejected value is [foo__bar]",
         violation.getMessage());
+  }
+
+  @Test
+  public void isIdValidWithCustomSeparator() {
+    Set<ConstraintViolation<TestId>> violations =
+        validatorWithSeparator("___").validate(new TestId("foo__bar"));
+    assertEquals(0, violations.size());
+  }
+
+  @Test
+  public void isIdUsingCustomSeparator() {
+    Set<ConstraintViolation<TestId>> violations =
+        validatorWithSeparator("___").validate(new TestId("foo___bar"));
+    assertEquals(1, violations.size());
+    ConstraintViolation<TestId> violation = violations.iterator().next();
+    assertEquals("foo___bar", violation.getInvalidValue());
+    assertEquals(
+        "[maestro id or name reference] cannot contain the step param separator '___' - rejected value is [foo___bar]",
+        violation.getMessage());
+  }
+
+  private Validator validatorWithSeparator(String separator) {
+    return Validation.byProvider(ApacheValidationProvider.class)
+        .configure()
+        .constraintValidatorFactory(
+            new ConstraintValidatorFactory() {
+              @Override
+              public <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
+                try {
+                  T instance = key.getDeclaredConstructor().newInstance();
+                  if (instance instanceof MaestroReferenceIdConstraint.MaestroIdValidator) {
+                    ((MaestroReferenceIdConstraint.MaestroIdValidator) instance)
+                        .setStepParamSeparator(() -> separator);
+                  }
+                  return instance;
+                } catch (Exception e) {
+                  throw new RuntimeException(e);
+                }
+              }
+
+              @Override
+              public void releaseInstance(ConstraintValidator<?, ?> instance) {}
+            })
+        .buildValidatorFactory()
+        .getValidator();
   }
 
   @Test

--- a/maestro-database/src/main/java/com/netflix/maestro/database/AbstractDatabaseDao.java
+++ b/maestro-database/src/main/java/com/netflix/maestro/database/AbstractDatabaseDao.java
@@ -407,19 +407,6 @@ public abstract class AbstractDatabaseDao {
   }
 
   /**
-   * Mark the current transaction as SERIALIZABLE isolation level.
-   *
-   * @param conn the connection
-   * @throws SQLException sql exception
-   */
-  protected void markTransactionSerializable(Connection conn) throws SQLException {
-    try (PreparedStatement stmt =
-        conn.prepareStatement("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")) {
-      stmt.execute();
-    }
-  }
-
-  /**
    * Mark the current transaction as SERIALIZABLE READ ONLY isolation level.
    *
    * @param conn the connection

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/ParamEvaluator.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/ParamEvaluator.java
@@ -364,7 +364,10 @@ public class ParamEvaluator {
       String refParam, Map<String, Map<String, Object>> allStepOutputData) {
     int idx1 = refParam.indexOf(stepParamSeparator);
     int idx2 = refParam.lastIndexOf(stepParamSeparator);
-    //  ___ or ____ case
+    // Overlapping separator match: occurs when the step ID ends with a character that is also
+    // the start of the separator (e.g. step ID "_step1" with separator "__" produces
+    // "_step1___foo" where the separator matches at two positions). Disambiguate by checking
+    // which candidate step ID exists in allStepOutputData.
     if (idx1 != idx2) {
       String id1 = refParam.substring(0, idx1);
       String id2 = refParam.substring(0, idx1 + 1);

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/ParamEvaluator.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/ParamEvaluator.java
@@ -59,13 +59,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @AllArgsConstructor
 public class ParamEvaluator {
-  private static final String STEP_PARAM_SEPARATOR = "__";
   private static final String SIGNAL_EXPRESSION_TEMPLATE =
       "return params.getFromSignal('%s', '%s');";
   private static final String PARAM_NAME_FOR_ALL = "params";
 
   private final ExprEvaluator exprEvaluator;
   private final ObjectMapper objectMapper;
+  private final String stepParamSeparator;
+
+  /** Convenience constructor using the default step param separator {@code __}. */
+  public ParamEvaluator(ExprEvaluator exprEvaluator, ObjectMapper objectMapper) {
+    this(exprEvaluator, objectMapper, "__");
+  }
 
   /**
    * Evaluate workflow parameters.
@@ -154,7 +159,7 @@ public class ParamEvaluator {
         parseWorkflowParameter(
             workflowParams, workflowParams.get(refParamName), workflowId, visited);
         refParams.put(refParamName, workflowParams.get(refParamName));
-      } else if (refParamName.contains(STEP_PARAM_SEPARATOR)) {
+      } else if (refParamName.contains(stepParamSeparator)) {
         // here it might be from signal triggers
         Map.Entry<String, String> pair = parseReferenceName(refParamName, Collections.emptyMap());
         refParams.put(
@@ -313,7 +318,7 @@ public class ParamEvaluator {
       Set<String> visited) {
     Map<String, Parameter> usedParams = new HashMap<>();
     for (String refParam : refParamNames) {
-      if (refParam.contains(STEP_PARAM_SEPARATOR)) {
+      if (refParam.contains(stepParamSeparator)) {
         usedParams.put(
             refParam,
             getReferenceParam(
@@ -353,8 +358,8 @@ public class ParamEvaluator {
   /** Extract step id and param name from the reference. It handles `__`, `___`, and `____`. */
   private Map.Entry<String, String> parseReferenceName(
       String refParam, Map<String, Map<String, Object>> allStepOutputData) {
-    int idx1 = refParam.indexOf(STEP_PARAM_SEPARATOR);
-    int idx2 = refParam.lastIndexOf(STEP_PARAM_SEPARATOR);
+    int idx1 = refParam.indexOf(stepParamSeparator);
+    int idx2 = refParam.lastIndexOf(stepParamSeparator);
     //  ___ or ____ case
     if (idx1 != idx2) {
       String id1 = refParam.substring(0, idx1);
@@ -374,7 +379,7 @@ public class ParamEvaluator {
       }
     }
     String refStepId = refParam.substring(0, idx1);
-    String refParamName = refParam.substring(idx1 + 2);
+    String refParamName = refParam.substring(idx1 + stepParamSeparator.length());
     return new AbstractMap.SimpleEntry<>(refStepId, refParamName);
   }
 

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/ParamEvaluator.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/ParamEvaluator.java
@@ -62,6 +62,7 @@ public class ParamEvaluator {
   private static final String SIGNAL_EXPRESSION_TEMPLATE =
       "return params.getFromSignal('%s', '%s');";
   private static final String PARAM_NAME_FOR_ALL = "params";
+  private static final String DEFAULT_STEP_PARAM_SEPARATOR = "__";
 
   private final ExprEvaluator exprEvaluator;
   private final ObjectMapper objectMapper;
@@ -69,7 +70,7 @@ public class ParamEvaluator {
 
   /** Convenience constructor using the default step param separator {@code __}. */
   public ParamEvaluator(ExprEvaluator exprEvaluator, ObjectMapper objectMapper) {
-    this(exprEvaluator, objectMapper, "__");
+    this(exprEvaluator, objectMapper, DEFAULT_STEP_PARAM_SEPARATOR);
   }
 
   /**
@@ -355,7 +356,11 @@ public class ParamEvaluator {
     return usedParams;
   }
 
-  /** Extract step id and param name from the reference. It handles `__`, `___`, and `____`. */
+  /**
+   * Extract step id and param name from the reference. It handles separator, separator with one
+   * extra underscore, and separator with two extra underscores (e.g. {@code __}, {@code ___}, and
+   * {@code ____} for the default separator).
+   */
   private Map.Entry<String, String> parseReferenceName(
       String refParam, Map<String, Map<String, Object>> allStepOutputData) {
     int idx1 = refParam.indexOf(stepParamSeparator);

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/ParamEvaluator.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/eval/ParamEvaluator.java
@@ -62,7 +62,6 @@ public class ParamEvaluator {
   private static final String SIGNAL_EXPRESSION_TEMPLATE =
       "return params.getFromSignal('%s', '%s');";
   private static final String PARAM_NAME_FOR_ALL = "params";
-  private static final String DEFAULT_STEP_PARAM_SEPARATOR = "__";
 
   private final ExprEvaluator exprEvaluator;
   private final ObjectMapper objectMapper;
@@ -70,7 +69,7 @@ public class ParamEvaluator {
 
   /** Convenience constructor using the default step param separator {@code __}. */
   public ParamEvaluator(ExprEvaluator exprEvaluator, ObjectMapper objectMapper) {
-    this(exprEvaluator, objectMapper, DEFAULT_STEP_PARAM_SEPARATOR);
+    this(exprEvaluator, objectMapper, Constants.DEFAULT_STEP_PARAM_SEPARATOR);
   }
 
   /**

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/eval/ParamEvaluatorTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/eval/ParamEvaluatorTest.java
@@ -312,6 +312,21 @@ public class ParamEvaluatorTest extends MaestroEngineBaseTest {
   }
 
   @Test
+  public void testParseStepParameterWithCustomSeparator() {
+    ParamEvaluator customEvaluator = new ParamEvaluator(evaluator, MAPPER, "___");
+    StringParameter bar =
+        StringParameter.builder().name("bar").expression("step1___foo + '-1';").build();
+    customEvaluator.parseStepParameter(
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.singletonMap(
+            "foo", StringParameter.builder().evaluatedResult("123").evaluatedTime(123L).build()),
+        bar,
+        "step1");
+    assertEquals("123-1", bar.getEvaluatedResult());
+  }
+
+  @Test
   public void testParseStepParameterUsingParamsToGetWorkflowParams() {
     StringParameter bar =
         StringParameter.builder().name("bar").expression("params.get('foo') + '-1'").build();

--- a/maestro-server/src/main/java/com/netflix/maestro/server/config/MaestroEngineConfiguration.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/config/MaestroEngineConfiguration.java
@@ -34,6 +34,7 @@ import com.netflix.maestro.models.Constants;
 import com.netflix.maestro.server.properties.MaestroProperties;
 import com.netflix.maestro.server.properties.StepRuntimeProperties;
 import com.netflix.maestro.utils.JsonHelper;
+import com.netflix.maestro.utils.StepParamSeparator;
 import com.netflix.spectator.api.DefaultRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -143,10 +144,18 @@ public class MaestroEngineConfiguration {
   }
 
   @Bean
+  public StepParamSeparator stepParamSeparator(MaestroProperties properties) {
+    LOG.info("Creating maestro stepParamSeparator within Spring boot...");
+    return properties.getParamEvaluator();
+  }
+
+  @Bean
   public ParamEvaluator paramEvaluatorHelper(
       ExprEvaluator exprEvaluator,
-      @Qualifier(Constants.MAESTRO_QUALIFIER) ObjectMapper objectMapper) {
+      @Qualifier(Constants.MAESTRO_QUALIFIER) ObjectMapper objectMapper,
+      MaestroProperties properties) {
     LOG.info("Creating maestro parameterHelper within Spring boot...");
-    return new ParamEvaluator(exprEvaluator, objectMapper);
+    return new ParamEvaluator(
+        exprEvaluator, objectMapper, properties.getParamEvaluator().getStepParamSeparator());
   }
 }

--- a/maestro-server/src/main/java/com/netflix/maestro/server/properties/MaestroProperties.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/properties/MaestroProperties.java
@@ -27,5 +27,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class MaestroProperties {
   private final QueueProperties queue;
   private final SelProperties sel;
+  private final ParamEvaluatorProperties paramEvaluator;
   private final StepActionProperties stepAction;
+
+  /** Returns the param evaluator properties, defaulting to {@code __} separator if not set. */
+  public ParamEvaluatorProperties getParamEvaluator() {
+    return paramEvaluator != null ? paramEvaluator : new ParamEvaluatorProperties();
+  }
 }

--- a/maestro-server/src/main/java/com/netflix/maestro/server/properties/ParamEvaluatorProperties.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/properties/ParamEvaluatorProperties.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.maestro.server.properties;
+
+import com.netflix.maestro.utils.StepParamSeparator;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Parameter evaluator properties. Please check {@link
+ * com.netflix.maestro.engine.eval.ParamEvaluator} about how they are used.
+ */
+@Getter
+@Setter
+public class ParamEvaluatorProperties implements StepParamSeparator {
+  private String stepParamSeparator = "__";
+}

--- a/maestro-server/src/main/java/com/netflix/maestro/server/properties/ParamEvaluatorProperties.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/properties/ParamEvaluatorProperties.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.maestro.server.properties;
 
+import com.netflix.maestro.models.Constants;
 import com.netflix.maestro.utils.StepParamSeparator;
 import lombok.Getter;
 import lombok.Setter;
@@ -23,5 +24,5 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ParamEvaluatorProperties implements StepParamSeparator {
-  private String stepParamSeparator = "__";
+  private String stepParamSeparator = Constants.DEFAULT_STEP_PARAM_SEPARATOR;
 }


### PR DESCRIPTION

Pull Request type
----
- [ ] Bugfix
- [ x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

The step parameter separator (default `__`) used in cross-step references like `step1__param` was previously hardcoded. As a result, any step ID or parameter name containing `__ ` was rejected by validation.

This PR makes the separator configurable via maestro.param-evaluator.step-param-separator. Netflix OSS users keep the existing behavior (__ by default). Teams can now choose a different separator (e.g., `___`), allowing `__ `to appear freely in step IDs and parameter names without triggering validation errors.
