### PR TITLE
Endpoint to get latest step instance views across runs for a given workflow instance 

### DIFF
--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroStepInstanceDao.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroStepInstanceDao.java
@@ -184,6 +184,12 @@ public class MaestroStepInstanceDao extends AbstractDatabaseDao {
           + GET_STEP_FIELD_QUERY_FROM
           + "AND workflow_run_id=?) SELECT * FROM inner_ranked WHERE rank=1";
 
+  private static final String GET_ALL_STEP_INSTANCE_VIEWS_QUERY =
+      INNER_RANK_QUERY_ALL_FIELD_WITH
+          + ", ROW_NUMBER() OVER (PARTITION BY step_id ORDER BY workflow_run_id DESC, step_attempt_id DESC) AS rank"
+          + GET_STEP_FIELD_QUERY_FROM
+          + ") SELECT * FROM inner_ranked WHERE rank=1";
+
   private final MaestroQueueSystem queueSystem;
 
   /**
@@ -1227,6 +1233,37 @@ public class MaestroStepInstanceDao extends AbstractDatabaseDao {
                 }),
         "getNextUniqueId",
         "Failed to get the next unique id");
+  }
+
+  /**
+   * Get the latest step attempts of all the steps across all runs for a given workflow instance
+   * (workflow id, instance id).
+   *
+   * @param workflowId workflow id
+   * @param workflowInstanceId workflow instance id
+   * @return latest step attempts of all the steps across all runs
+   */
+  public List<StepInstance> getAllStepInstanceViews(String workflowId, long workflowInstanceId) {
+    return withMetricLogError(
+        () ->
+            withRetryableQuery(
+                GET_ALL_STEP_INSTANCE_VIEWS_QUERY,
+                stmt -> {
+                  int idx = 0;
+                  stmt.setString(++idx, workflowId);
+                  stmt.setLong(++idx, workflowInstanceId);
+                },
+                result -> {
+                  List<StepInstance> instances = new ArrayList<>();
+                  while (result.next()) {
+                    instances.add(maestroStepFromResult(result));
+                  }
+                  return instances;
+                }),
+        "getAllStepInstanceViews",
+        "Failed to get latest step attempts across all runs for workflow instance [{}][{}]",
+        workflowId,
+        workflowInstanceId);
   }
 
   /**

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroStepInstanceDaoTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroStepInstanceDaoTest.java
@@ -54,6 +54,7 @@ import com.netflix.maestro.queue.jobevents.MaestroJobEvent;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -319,6 +320,37 @@ public class MaestroStepInstanceDaoTest extends MaestroDaoBaseTest {
     instance.setArtifacts(null);
     instance.setTimeline(null);
     Assertions.assertThat(instance).usingRecursiveComparison().isEqualTo(si);
+  }
+
+  @Test
+  public void testGetAllStepInstanceViews() throws Exception {
+    // run 1: job1 (RUNNING) already seeded by setUp; add job2 (RUNNING) to the same run
+    StepInstance job2Run1 = loadObject(TEST_STEP_INSTANCE, StepInstance.class);
+    job2Run1.setStepId("job2");
+    job2Run1.setStepInstanceId(2);
+    stepDao.insertOrUpsertStepInstance(job2Run1, false, null);
+
+    // run 2 (restart from failure): only job1 ran again — job2 succeeded in run 1 and was skipped
+    StepInstance job1Run2 =
+        loadObject("fixtures/instances/sample-step-instance-finishing.json", StepInstance.class);
+    stepDao.insertOrUpsertStepInstance(job1Run2, false, null);
+
+    // should return one entry per step: job1 from run 2, job2 from run 1
+    List<StepInstance> instances = stepDao.getAllStepInstanceViews(TEST_WORKFLOW_ID, 1);
+    instances.sort(Comparator.comparingLong(StepInstance::getStepInstanceId));
+    assertEquals(2, instances.size());
+
+    StepInstance job1Result = instances.get(0);
+    assertEquals("job1", job1Result.getStepId());
+    assertEquals(2, job1Result.getWorkflowRunId());
+    assertEquals(StepInstance.Status.FINISHING, job1Result.getRuntimeState().getStatus());
+    assertEquals("ff4ccce2-0fda-4882-9cd8-12ff90cb5f02", job1Result.getStepUuid());
+
+    StepInstance job2Result = instances.get(1);
+    assertEquals("job2", job2Result.getStepId());
+    assertEquals(1, job2Result.getWorkflowRunId());
+    assertEquals(StepInstance.Status.RUNNING, job2Result.getRuntimeState().getStatus());
+    assertEquals("ff4ccce2-0fda-4882-9cd8-12ff90cb5f06", job2Result.getStepUuid());
   }
 
   @Test

--- a/maestro-server/src/main/java/com/netflix/maestro/server/controllers/StepInstanceController.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/controllers/StepInstanceController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
     value = "/api/v3/workflows",
     produces = MediaType.APPLICATION_JSON_VALUE,
     consumes = MediaType.APPLICATION_JSON_VALUE)
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class StepInstanceController {
 
   private final MaestroStepInstanceDao stepInstanceDao;
@@ -86,6 +87,20 @@ public class StepInstanceController {
       instance.enrich();
     }
     return instance;
+  }
+
+  @GetMapping(
+      value = "/{workflowId}/instances/{workflowInstanceId}/steps",
+      consumes = MediaType.ALL_VALUE)
+  @Operation(
+      summary = "Get the most recent step instance across all runs for a given workflow instance")
+  public List<StepInstance> getAllStepInstanceViews(
+      @Valid @NotNull @PathVariable("workflowId") String workflowId,
+      @PathVariable("workflowInstanceId") long workflowInstanceId) {
+    List<StepInstance> instances =
+        stepInstanceDao.getAllStepInstanceViews(workflowId, workflowInstanceId);
+    instances.sort(Comparator.comparingLong(StepInstance::getStepInstanceId));
+    return instances;
   }
 
   @GetMapping(

--- a/maestro-server/src/test/java/com/netflix/maestro/server/controllers/StepInstanceControllerTest.java
+++ b/maestro-server/src/test/java/com/netflix/maestro/server/controllers/StepInstanceControllerTest.java
@@ -127,4 +127,19 @@ public class StepInstanceControllerTest extends MaestroBaseTest {
     assertEquals(1, ret.size());
     assertEquals(instance2, ret.get(0));
   }
+
+  @Test
+  public void testGetAllStepInstanceViews() {
+    StepInstance instance1 = mock(StepInstance.class);
+    StepInstance instance2 = mock(StepInstance.class);
+    when(instance1.getStepInstanceId()).thenReturn(2L);
+    when(instance2.getStepInstanceId()).thenReturn(1L);
+    when(mockInstanceDao.getAllStepInstanceViews("test-workflow", 1))
+        .thenReturn(Arrays.asList(instance1, instance2));
+    List<StepInstance> ret = stepInstanceController.getAllStepInstanceViews("test-workflow", 1);
+    verify(mockInstanceDao, times(1)).getAllStepInstanceViews("test-workflow", 1);
+    assertEquals(2, ret.size());
+    assertEquals(instance2, ret.get(0));
+    assertEquals(instance1, ret.get(1));
+  }
 }


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Add endpoint to get latest step instance views across all runs for a workflow instance

Adds `GET /{workflowId}/instances/{workflowInstanceId}/steps` which returns the most recent step attempt per step across all runs, useful for workflows restarted from failure where steps ran in different runs.

Why is this needed
----

 This endpoint makes it easy to get a snapshot of the current state of all steps in a workflow instance, regardless of how many times it has been restarted.      
Currently, to understand the final state of each step you need to know the latest run ID and call the run-specific `/runs/{runId}/steps` endpoint. But for restarted workflows, different steps may have completed in different runs — some steps succeed  early and are skipped in subsequent runs.                                                                                                                                                       
The`GET /{workflowId}/instances/{workflowInstanceId}/steps` endpoint added in this PR solves this by querying across all runs and returns the most recent attempt per step, giving a complete and accurate view of the workflow instance's step states in a  single call.
                                                                                                                                                                                                                                                                    
  ### Example     

  Say you have a workflow with 3 steps: **step-a**, **step-b**, **step-c**.                                                                                                                                                                                         
   
  **Run 1** — all 3 steps ran, but step-c failed:                                                                                                                                                                                                                   
  | step | run | status |
  |---|---|---|
  | step-a | 1 | SUCCEEDED |
  | step-b | 1 | SUCCEEDED |
  | step-c | 1 | FAILED |                                                                                                                                                                                                                                           
   
  **Run 2** — restarted from failure, only step-c ran again:                                                                                                                                                                                                        
  | step | run | status |
  |---|---|---|                                                                                                                                                                                                                                                     
  | step-c | 2 | SUCCEEDED |
                                                                                                                                                                                                                                                                    
  **`GET /instances/1/runs/2/steps`** (existing) — incomplete, only shows steps from run 2:                                                                                                                                                                              
  | step | run | status |                                                                                                                                                                                                                                           
  |---|---|---|                                                                                                                                                                                                                                                     
  | step-c | 2 | SUCCEEDED |
                                                                                                                                                                                                                                                                    
  **`GET /instances/1/steps`** (new) — complete picture, latest attempt per step across all runs:                                                                                                                                                                   
  | step | run | status |                                                                                                                                                                                                                                           
  |---|---|---|                                                                                                                                                                                                                                                     
  | step-a | 1 | SUCCEEDED |
  | step-b | 1 | SUCCEEDED |
  | step-c | 2 | SUCCEEDED |


### Testing
----
                                                                                                                                                                                                                                                                    
  **DAO (`MaestroStepInstanceDaoTest`):**                                                                                                                                                                                                                           
  - `testGetAllStepInstanceViews` — simulates a restart-from-failure scenario: run 1 has two steps (job1, job2), run 2 only re-ran job1. Verifies that job1 is returned from run 2 and job2 from run 1 — i.e. the most recent attempt per step is correctly selected
   across runs.                                                                                                                                                                                                                                                     
                  
  **Controller (`StepInstanceControllerTest`):**                                                                                                                                                                                                                    
  - `testGetAllStepInstanceViews` — verifies the DAO is called with correct arguments and the result is sorted by `stepInstanceId`.

  **Locally:**
- Also tested locally by spinning the server , creating a workflow, triggering multiple runs, and verifying endpoint returns as expected