### PR TITLE
Expose Kubernetes PreStop lifecycle hook for Kubernetes step type

### DIFF
--- a/maestro-common/src/main/java/com/netflix/maestro/models/stepruntime/KubernetesCommand.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/stepruntime/KubernetesCommand.java
@@ -41,7 +41,8 @@ import lombok.ToString;
       "entrypoint",
       "env",
       "job_deduplication_key",
-      "owner_email"
+      "owner_email",
+      "pre_stop"
     },
     alphabetic = true)
 @Builder(toBuilder = true)
@@ -69,9 +70,44 @@ public class KubernetesCommand {
   private final Map<String, String> env;
   private final String jobDeduplicationKey;
   private final String ownerEmail;
+  private final PreStop preStop;
 
   /** builder class for lombok and jackson. */
   @JsonPOJOBuilder(withPrefix = "")
   @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
   public static final class KubernetesCommandBuilder {}
+
+  /** PreStop container lifecycle hook. Mirrors the shape of K8s Container.lifecycle.preStop. */
+  @JsonDeserialize(builder = PreStop.PreStopBuilder.class)
+  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Builder(toBuilder = true)
+  @Getter
+  @ToString
+  @EqualsAndHashCode
+  public static class PreStop {
+    private final Exec exec;
+
+    /** builder class for lombok and jackson. */
+    @JsonPOJOBuilder(withPrefix = "")
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static final class PreStopBuilder {}
+
+    /** Exec handler for a lifecycle hook. Mirrors the shape of K8s LifecycleHandler.exec. */
+    @JsonDeserialize(builder = Exec.ExecBuilder.class)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Builder(toBuilder = true)
+    @Getter
+    @ToString
+    @EqualsAndHashCode
+    public static class Exec {
+      private final String[] command;
+
+      /** builder class for lombok and jackson. */
+      @JsonPOJOBuilder(withPrefix = "")
+      @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+      public static final class ExecBuilder {}
+    }
+  }
 }

--- a/maestro-common/src/test/java/com/netflix/maestro/models/stepruntime/KubernetesCommandTest.java
+++ b/maestro-common/src/test/java/com/netflix/maestro/models/stepruntime/KubernetesCommandTest.java
@@ -39,4 +39,15 @@ public class KubernetesCommandTest extends MaestroBaseTest {
     assertEquals(expected, actual);
     assertEquals(ser1, ser2);
   }
+
+  @Test
+  public void testRoundTripSerdeWithPreStop() throws Exception {
+    KubernetesCommand expected =
+        loadObject("fixtures/stepruntime/kubernetes_command_prestop.json", KubernetesCommand.class);
+    String ser1 = MAPPER.writeValueAsString(expected);
+    KubernetesCommand actual = MAPPER.readValue(ser1, KubernetesCommand.class);
+    String ser2 = MAPPER.writeValueAsString(actual);
+    assertEquals(expected, actual);
+    assertEquals(ser1, ser2);
+  }
 }

--- a/maestro-common/src/testFixtures/resources/fixtures/stepruntime/kubernetes_command_prestop.json
+++ b/maestro-common/src/testFixtures/resources/fixtures/stepruntime/kubernetes_command_prestop.json
@@ -1,0 +1,17 @@
+{
+  "app_name": "maestro",
+  "args": ["hello", "world"],
+  "command": ["echo"],
+  "cpu": "0.5",
+  "disk": "1G",
+  "image": "test-image",
+  "env": {
+    "foo": "bar"
+  },
+  "job_deduplication_key": "job-dedup-key-1",
+  "pre_stop": {
+    "exec": {
+      "command": ["/bin/sh", "-c", "cleanup.sh --flag"]
+    }
+  }
+}

--- a/maestro-kubernetes/src/main/resources/defaultparams/default-kubernetes-step-params.yaml
+++ b/maestro-kubernetes/src/main/resources/defaultparams/default-kubernetes-step-params.yaml
@@ -36,6 +36,17 @@ kubernetes:
     owner_email:
       type: STRING
       internal_mode: OPTIONAL
+    pre_stop:
+      type: MAP
+      internal_mode: OPTIONAL
+      value:
+        exec:
+          type: MAP
+          internal_mode: OPTIONAL
+          value:
+            command:
+              type: STRING_ARRAY
+              internal_mode: OPTIONAL
   internal_mode: REQUIRED
   tags:
     - kubernetes

--- a/maestro-kubernetes/src/test/java/com/netflix/maestro/engine/kubernetes/KubernetesCommandGeneratorTest.java
+++ b/maestro-kubernetes/src/test/java/com/netflix/maestro/engine/kubernetes/KubernetesCommandGeneratorTest.java
@@ -89,9 +89,16 @@ public class KubernetesCommandGeneratorTest extends MaestroBaseTest {
             MapParameter.builder()
                 .evaluatedResult(
                     Map.of(
-                        "image", "test-image",
-                        "command", new String[] {"echo"},
-                        "args", new String[] {"hello", "world"}))
+                        "image",
+                        "test-image",
+                        "command",
+                        new String[] {"echo"},
+                        "args",
+                        new String[] {"hello", "world"},
+                        "pre_stop",
+                        Map.of(
+                            "exec",
+                            Map.of("command", new String[] {"/bin/sh", "-c", "cleanup.sh"}))))
                 .evaluatedTime(12345L)
                 .build());
     KubernetesStepContext context =
@@ -100,6 +107,8 @@ public class KubernetesCommandGeneratorTest extends MaestroBaseTest {
     assertEquals("test-image", command.getImage());
     assertArrayEquals(new String[] {"echo"}, command.getCommand());
     assertArrayEquals(new String[] {"hello", "world"}, command.getArgs());
+    assertArrayEquals(
+        new String[] {"/bin/sh", "-c", "cleanup.sh"}, command.getPreStop().getExec().getCommand());
     assertNull(command.getEntrypoint());
   }
 
@@ -120,6 +129,7 @@ public class KubernetesCommandGeneratorTest extends MaestroBaseTest {
     assertEquals("test-image", command.getImage());
     assertNull(command.getCommand());
     assertNull(command.getArgs());
+    assertNull(command.getPreStop());
     assertNull(command.getEntrypoint());
   }
 

--- a/maestro-server/src/main/java/com/netflix/maestro/server/runtime/Fabric8RuntimeExecutor.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/runtime/Fabric8RuntimeExecutor.java
@@ -20,6 +20,8 @@ import com.netflix.maestro.exceptions.MaestroBadRequestException;
 import com.netflix.maestro.models.stepruntime.KubernetesCommand;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
+import io.fabric8.kubernetes.api.model.Lifecycle;
+import io.fabric8.kubernetes.api.model.LifecycleBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodStatus;
@@ -27,6 +29,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -146,9 +149,28 @@ public class Fabric8RuntimeExecutor implements KubernetesRuntimeExecutor {
         .withCommand(command.getCommand())
         .withArgs(command.getArgs())
         .withEnv(envVars)
+        .withLifecycle(buildPreStopLifecycle(command))
         .endContainer()
         .withRestartPolicy("Never")
         .endSpec()
+        .build();
+  }
+
+  private Lifecycle buildPreStopLifecycle(KubernetesCommand command) {
+    KubernetesCommand.PreStop preStop = command.getPreStop();
+    if (preStop == null || preStop.getExec() == null) {
+      return null;
+    }
+    String[] execCommand = preStop.getExec().getCommand();
+    if (execCommand == null || execCommand.length == 0) {
+      return null;
+    }
+    return new LifecycleBuilder()
+        .withNewPreStop()
+        .withNewExec()
+        .withCommand(Arrays.asList(execCommand))
+        .endExec()
+        .endPreStop()
         .build();
   }
 

--- a/maestro-server/src/test/java/com/netflix/maestro/server/runtime/Fabric8RuntimeExecutorTest.java
+++ b/maestro-server/src/test/java/com/netflix/maestro/server/runtime/Fabric8RuntimeExecutorTest.java
@@ -13,6 +13,7 @@
 package com.netflix.maestro.server.runtime;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -125,6 +126,59 @@ public class Fabric8RuntimeExecutorTest extends MaestroBaseTest {
     var container = pod.getSpec().getContainers().getFirst();
     assertTrue(container.getCommand() == null || container.getCommand().isEmpty());
     assertTrue(container.getArgs() == null || container.getArgs().isEmpty());
+  }
+
+  @Test
+  public void testLaunchJobWithoutPreStop() {
+    KubernetesCommand command =
+        KubernetesCommand.builder()
+            .jobDeduplicationKey("test-job")
+            .image("test-image")
+            .command(new String[] {"echo"})
+            .args(new String[] {"hello"})
+            .env(Collections.emptyMap())
+            .build();
+    KubernetesStepContext context = buildContext(command);
+
+    ArgumentCaptor<Pod> podCaptor = ArgumentCaptor.forClass(Pod.class);
+    when(nsOp.resource(podCaptor.capture())).thenReturn(podResource);
+
+    executor.launchJob(context);
+
+    Pod pod = podCaptor.getValue();
+    var container = pod.getSpec().getContainers().getFirst();
+    assertNull(container.getLifecycle());
+  }
+
+  @Test
+  public void testLaunchJobWithPreStopExec() {
+    KubernetesCommand command =
+        KubernetesCommand.builder()
+            .jobDeduplicationKey("test-job")
+            .image("test-image")
+            .command(new String[] {"echo"})
+            .args(new String[] {"hello"})
+            .env(Collections.emptyMap())
+            .preStop(
+                KubernetesCommand.PreStop.builder()
+                    .exec(
+                        KubernetesCommand.PreStop.Exec.builder()
+                            .command(new String[] {"/bin/sh", "-c", "cleanup.sh --flag"})
+                            .build())
+                    .build())
+            .build();
+    KubernetesStepContext context = buildContext(command);
+
+    ArgumentCaptor<Pod> podCaptor = ArgumentCaptor.forClass(Pod.class);
+    when(nsOp.resource(podCaptor.capture())).thenReturn(podResource);
+
+    executor.launchJob(context);
+
+    Pod pod = podCaptor.getValue();
+    var container = pod.getSpec().getContainers().getFirst();
+    assertEquals(
+        List.of("/bin/sh", "-c", "cleanup.sh --flag"),
+        container.getLifecycle().getPreStop().getExec().getCommand());
   }
 
   private KubernetesStepContext buildContext(KubernetesCommand command) {


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----
 - Adds a `pre_stop` param on the Kubernetes step type that maps 1:1 to the K8s `Container.lifecycle.preStop` API (`pre_stop.exec.command: [...]`), attaching to the main step container so step authors can run
   cleanup before SIGTERM.                                                                                                                                                                                       
  - Field is optional with no default — when unset, no `Lifecycle` is attached to the container and existing workflows are unaffected.                                                                           
  - Only the `exec` handler form is exposed in this change; `httpGet`/`tcpSocket`/`sleep` can be added as sibling fields later without a breaking schema change.


