### PR TITLE
Make Properties.alerting a pluggable interface

### DIFF
--- a/maestro-common/src/main/java/com/netflix/maestro/models/definition/Alerting.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/definition/Alerting.java
@@ -34,9 +34,7 @@ import java.util.function.Function;
  * </pre>
  *
  * <p>A later-registered abstract-type mapping replaces the OSS default, so the consumer's impl
- * wins. We avoid {@code @JsonDeserialize(as = DefaultAlerting.class)} on the interface because
- * Jackson would still apply that annotation after the abstract-type mapping resolved a different
- * concrete class, producing a "not subtype of" error during type narrowing.
+ * wins.
  *
  * <p>Each running JVM uses exactly one {@code Alerting} implementation, so no JSON type
  * discriminator is needed. Existing serialized data continues to deserialize as {@link

--- a/maestro-common/src/main/java/com/netflix/maestro/models/definition/Alerting.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/definition/Alerting.java
@@ -12,144 +12,43 @@
  */
 package com.netflix.maestro.models.definition;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.netflix.maestro.models.definition.alerting.AlertType;
-import com.netflix.maestro.models.definition.alerting.AlertingTypeConfig;
-import com.netflix.maestro.models.definition.alerting.BypassDigestConfig;
 import com.netflix.maestro.models.parameter.ParamDefinition;
 import com.netflix.maestro.models.parameter.Parameter;
-import com.netflix.maestro.utils.StringParser;
-import com.netflix.maestro.validations.TctConstraint;
-import jakarta.validation.constraints.NotNull;
-import java.io.Serializable;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import lombok.Data;
-import lombok.Getter;
 
-/** Alerting config. */
-@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-@JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder(
-    value = {
-      "emails",
-      "pagerduties",
-      "slack",
-      "bypass_digest_config",
-      "pagerduty_configs",
-      "tct",
-      "type_configs"
-    },
-    alphabetic = true)
-@Data
-public class Alerting {
-
-  private Set<String> emails;
-  private Set<String> pagerduties;
-
-  @JsonProperty("slack")
-  private SlackConfig slackConfig;
-
-  private BypassDigestConfig bypassDigestConfig;
-
-  private Map<AlertType, AlertingTypeConfig> typeConfigs;
-
-  private PagerdutyConfig pagerdutyConfig;
-
-  @TctConstraint private Tct tct;
-
-  /** Slack portion of {@link Alerting}. */
-  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @JsonPropertyOrder(
-      value = {
-        "users",
-        "channels",
-        "mention_users",
-      },
-      alphabetic = true)
-  @Data
-  public static class SlackConfig implements Serializable {
-
-    private static final long serialVersionUID = -5354026172019808586L;
-
-    private Set<String> users;
-    private Set<String> channels;
-    private Set<String> mentionUsers;
-  }
-
-  /** Pagerduty configurations of {@link Alerting}. */
-  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @JsonPropertyOrder(
-      value = {
-        "severity",
-        "always_page",
-      },
-      alphabetic = true)
-  @Data
-  public static class PagerdutyConfig implements Serializable {
-
-    private static final long serialVersionUID = -5354026172019808586L;
-
-    private Severity severity;
-    private Boolean alwaysPage;
-
-    /**
-     * <a
-     * href="https://support.pagerduty.com/docs/dynamic-notifications#eventalert-severity-levels">Pagerduty
-     * severity</a>.
-     */
-    public enum Severity {
-      /** critical. */
-      CRITICAL("critical"),
-
-      /** error. */
-      ERROR("error"),
-
-      /** warning. */
-      WARNING("warning"),
-
-      /** info. */
-      INFO("info");
-
-      @JsonIgnore @Getter private final String name;
-
-      Severity(final String name) {
-        this.name = name;
-      }
-
-      /** Static creator. */
-      @JsonCreator
-      public static Severity create(@NotNull String name) {
-        return Severity.valueOf(name.toUpperCase(Locale.US));
-      }
-    }
-  }
-
-  /** Update alerting fields by parsing parameters within it. */
+/**
+ * Pluggable alerting config carried on a workflow's {@link Properties}. The engine does not
+ * interpret the contents of this block; downstream consumers (notification services, dashboards,
+ * runtime hooks) read it via their own logic.
+ *
+ * <p>The default implementation, {@link DefaultAlerting}, preserves the original Netflix-flavored
+ * shape and is registered as the default abstract-type mapping inside {@link
+ * com.netflix.maestro.utils.JsonHelper#objectMapper()}. Downstream consumers can replace it by
+ * registering their own mapping:
+ *
+ * <pre>
+ *   SimpleModule module = new SimpleModule();
+ *   module.addAbstractTypeMapping(Alerting.class, MyAlerting.class);
+ *   mapper.registerModule(module);
+ * </pre>
+ *
+ * <p>A later-registered abstract-type mapping replaces the OSS default, so the consumer's impl
+ * wins. We avoid {@code @JsonDeserialize(as = DefaultAlerting.class)} on the interface because
+ * Jackson would still apply that annotation after the abstract-type mapping resolved a different
+ * concrete class, producing a "not subtype of" error during type narrowing.
+ *
+ * <p>Each running JVM uses exactly one {@code Alerting} implementation, so no JSON type
+ * discriminator is needed. Existing serialized data continues to deserialize as {@link
+ * DefaultAlerting} on any mapper that doesn't register a different mapping.
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface Alerting {
+  /**
+   * Update fields by parsing parameters within them. Implementations should resolve any parameter
+   * references (typically {@code ${...}} placeholders) using the provided parser. Called by the
+   * engine during workflow start.
+   */
   @JsonIgnore
-  public void update(Function<ParamDefinition, Parameter> paramParser) {
-    if (emails != null && !emails.isEmpty()) {
-      emails =
-          emails.stream()
-              .map(email -> StringParser.parseWithParam(email, paramParser))
-              .collect(Collectors.toSet());
-    }
-    if (tct != null) {
-      Parameter param = paramParser.apply(tct.getCompletedByTsParam());
-      if (param != null) {
-        tct.setCompletedByTs(param.asLong());
-      }
-    }
-  }
+  void update(Function<ParamDefinition, Parameter> paramParser);
 }

--- a/maestro-common/src/main/java/com/netflix/maestro/models/definition/DefaultAlerting.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/definition/DefaultAlerting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Netflix, Inc.
+ * Copyright 2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/maestro-common/src/main/java/com/netflix/maestro/models/definition/DefaultAlerting.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/definition/DefaultAlerting.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.maestro.models.definition;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.netflix.maestro.models.definition.alerting.AlertType;
+import com.netflix.maestro.models.definition.alerting.AlertingTypeConfig;
+import com.netflix.maestro.models.definition.alerting.BypassDigestConfig;
+import com.netflix.maestro.models.parameter.ParamDefinition;
+import com.netflix.maestro.models.parameter.Parameter;
+import com.netflix.maestro.utils.StringParser;
+import com.netflix.maestro.validations.TctConstraint;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.Getter;
+
+/** Default {@link Alerting} implementation preserving the original Netflix-flavored shape. */
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder(
+    value = {
+      "emails",
+      "pagerduties",
+      "slack",
+      "bypass_digest_config",
+      "pagerduty_configs",
+      "tct",
+      "type_configs"
+    },
+    alphabetic = true)
+@Data
+public class DefaultAlerting implements Alerting {
+
+  private Set<String> emails;
+  private Set<String> pagerduties;
+
+  @JsonProperty("slack")
+  private SlackConfig slackConfig;
+
+  private BypassDigestConfig bypassDigestConfig;
+
+  private Map<AlertType, AlertingTypeConfig> typeConfigs;
+
+  private PagerdutyConfig pagerdutyConfig;
+
+  @TctConstraint private Tct tct;
+
+  /** Slack portion of {@link DefaultAlerting}. */
+  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonPropertyOrder(
+      value = {
+        "users",
+        "channels",
+        "mention_users",
+      },
+      alphabetic = true)
+  @Data
+  public static class SlackConfig implements Serializable {
+
+    private static final long serialVersionUID = -5354026172019808586L;
+
+    private Set<String> users;
+    private Set<String> channels;
+    private Set<String> mentionUsers;
+  }
+
+  /** Pagerduty configurations of {@link DefaultAlerting}. */
+  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonPropertyOrder(
+      value = {
+        "severity",
+        "always_page",
+      },
+      alphabetic = true)
+  @Data
+  public static class PagerdutyConfig implements Serializable {
+
+    private static final long serialVersionUID = -5354026172019808586L;
+
+    private Severity severity;
+    private Boolean alwaysPage;
+
+    /**
+     * <a
+     * href="https://support.pagerduty.com/docs/dynamic-notifications#eventalert-severity-levels">Pagerduty
+     * severity</a>.
+     */
+    public enum Severity {
+      /** critical. */
+      CRITICAL("critical"),
+
+      /** error. */
+      ERROR("error"),
+
+      /** warning. */
+      WARNING("warning"),
+
+      /** info. */
+      INFO("info");
+
+      @JsonIgnore @Getter private final String name;
+
+      Severity(final String name) {
+        this.name = name;
+      }
+
+      /** Static creator. */
+      @JsonCreator
+      public static Severity create(@NotNull String name) {
+        return Severity.valueOf(name.toUpperCase(Locale.US));
+      }
+    }
+  }
+
+  @Override
+  public void update(Function<ParamDefinition, Parameter> paramParser) {
+    if (emails != null && !emails.isEmpty()) {
+      emails =
+          emails.stream()
+              .map(email -> StringParser.parseWithParam(email, paramParser))
+              .collect(Collectors.toSet());
+    }
+    if (tct != null) {
+      Parameter param = paramParser.apply(tct.getCompletedByTsParam());
+      if (param != null) {
+        tct.setCompletedByTs(param.asLong());
+      }
+    }
+  }
+}

--- a/maestro-common/src/main/java/com/netflix/maestro/models/definition/alerting/AlertingTypeConfig.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/definition/alerting/AlertingTypeConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.netflix.maestro.models.definition.Alerting;
+import com.netflix.maestro.models.definition.DefaultAlerting;
 import java.io.Serializable;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -42,7 +43,7 @@ public class AlertingTypeConfig implements Serializable {
   private Set<String> pagerduties;
 
   @JsonProperty("slack")
-  private Alerting.SlackConfig slackConfig;
+  private DefaultAlerting.SlackConfig slackConfig;
 
   @JsonIgnore private Set<Action> actions;
   private boolean disabled;

--- a/maestro-common/src/main/java/com/netflix/maestro/utils/JsonHelper.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/utils/JsonHelper.java
@@ -16,9 +16,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.netflix.maestro.exceptions.MaestroInternalError;
+import com.netflix.maestro.models.definition.Alerting;
+import com.netflix.maestro.models.definition.DefaultAlerting;
 
 /** Json helper utility class. */
 public final class JsonHelper {
@@ -55,6 +58,19 @@ public final class JsonHelper {
     mapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
     mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES, true);
     mapper.setNodeFactory(JsonNodeFactory.withExactBigDecimals(true));
+    mapper.registerModule(defaultAbstractTypeMappings());
+  }
+
+  /**
+   * Default abstract-type bindings for pluggable OSS interfaces. Downstream consumers can override
+   * any of these by registering their own SimpleModule with a different {@code
+   * addAbstractTypeMapping(...)}; a later-registered mapping replaces the one here. Add new
+   * pluggable abstract types to this module rather than to {@link #configureMapper(ObjectMapper)}.
+   */
+  private static SimpleModule defaultAbstractTypeMappings() {
+    SimpleModule module = new SimpleModule("MaestroDefaultAbstractTypes");
+    module.addAbstractTypeMapping(Alerting.class, DefaultAlerting.class);
+    return module;
   }
 
   /**

--- a/maestro-common/src/test/java/com/netflix/maestro/models/definition/AlertingTest.java
+++ b/maestro-common/src/test/java/com/netflix/maestro/models/definition/AlertingTest.java
@@ -53,12 +53,19 @@ public class AlertingTest {
     assertEquals(Set.of("alice@example.com"), ((DefaultAlerting) parsed).getEmails());
   }
 
+  /** Holder whose declared field type is the {@link Alerting} interface. */
+  public static class AlertingHolder {
+    public Alerting alerting;
+  }
+
   @Test
   public void defaultMapper_serializedJsonHasNoExtraTypeField() throws Exception {
     DefaultAlerting alerting = new DefaultAlerting();
     alerting.setEmails(Set.of("alice@example.com"));
+    AlertingHolder holder = new AlertingHolder();
+    holder.alerting = alerting;
     ObjectMapper mapper = JsonHelper.objectMapper();
-    String json = mapper.writeValueAsString(alerting);
+    String json = mapper.writeValueAsString(holder);
     assertFalse("JSON should not carry a type discriminator", json.contains("\"type\""));
   }
 

--- a/maestro-common/src/test/java/com/netflix/maestro/models/definition/AlertingTest.java
+++ b/maestro-common/src/test/java/com/netflix/maestro/models/definition/AlertingTest.java
@@ -12,171 +12,69 @@
  */
 package com.netflix.maestro.models.definition;
 
-import static com.netflix.maestro.models.definition.alerting.AlertType.*;
-import static com.netflix.maestro.models.definition.alerting.AlertingTypeConfig.Action.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.netflix.maestro.MaestroBaseTest;
-import com.netflix.maestro.models.definition.Alerting.PagerdutyConfig;
-import com.netflix.maestro.models.definition.alerting.AlertType;
-import com.netflix.maestro.models.definition.alerting.AlertingTypeConfig;
-import com.netflix.maestro.models.definition.alerting.BypassDigestConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.netflix.maestro.models.parameter.ParamDefinition;
 import com.netflix.maestro.models.parameter.Parameter;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumMap;
-import java.util.HashSet;
+import com.netflix.maestro.utils.JsonHelper;
 import java.util.Set;
-import org.junit.Before;
+import java.util.function.Function;
 import org.junit.Test;
 
-/** Tests for {@link Alerting}. */
-public class AlertingTest extends MaestroBaseTest {
+/** Tests covering the pluggable {@link Alerting} interface contract. */
+public class AlertingTest {
 
-  private Alerting expected;
+  /** Stand-in for a downstream consumer's custom {@link Alerting} implementation. */
+  public static class TestConsumerAlerting implements Alerting {
+    private String customField;
 
-  @Before
-  public void setupClass() {
-    AlertingTypeConfig stepFailureType = new AlertingTypeConfig();
-    stepFailureType.setEmails(Collections.singleton("demo+alertconfig_failure@netflix.com"));
-    stepFailureType.setPagerduties(Collections.singleton("alert config failure pager"));
-    Alerting.SlackConfig sfSlack = new Alerting.SlackConfig();
-    sfSlack.setChannels(Collections.singleton("channel_failure1"));
-    sfSlack.setUsers(Collections.singleton("failureuser"));
-    stepFailureType.setSlackConfig(sfSlack);
-    stepFailureType.setActions(new HashSet<>(Arrays.asList(EMAIL, PAGE, SLACK)));
+    public String getCustomField() {
+      return customField;
+    }
 
-    AlertingTypeConfig tctType = new AlertingTypeConfig();
-    tctType.setEmails(Collections.singleton("demo+alertconfig_tct@netflix.com"));
-    tctType.setPagerduties(Collections.singleton("alert config tct pager"));
-    Alerting.SlackConfig tctSlack = new Alerting.SlackConfig();
-    tctSlack.setUsers(Collections.singleton("tctuser"));
-    tctSlack.setChannels(Collections.singleton("channel_tct"));
-    tctSlack.setMentionUsers(new HashSet<>(Arrays.asList("tct_mention1", "tct_mention2")));
-    tctType.setSlackConfig(tctSlack);
-    tctType.setActions(new HashSet<>(Arrays.asList(CANCEL, PAGE, SLACK)));
+    public void setCustomField(String customField) {
+      this.customField = customField;
+    }
 
-    AlertingTypeConfig lrType = new AlertingTypeConfig();
-    lrType.setEmails(Collections.singleton("demo+alertconfig_longrunning@netflix.com"));
-    lrType.setPagerduties(Collections.singleton("alert config long running pager"));
-    Alerting.SlackConfig lrSlack = new Alerting.SlackConfig();
-    lrSlack.setUsers(Collections.singleton("longrunninguser"));
-    lrSlack.setChannels(
-        new HashSet<>(Arrays.asList("channel_longrunning1", "channel_longrunning2")));
-    lrType.setSlackConfig(lrSlack);
-    lrType.setActions(new HashSet<>(Arrays.asList(PAGE, EMAIL)));
-    lrType.setDisabled(true);
-    lrType.setGranularity(AlertingTypeConfig.Granularity.ALL);
-
-    AlertingTypeConfig bhType = new AlertingTypeConfig();
-    bhType.setEmails(Collections.singleton("demo+alertconfig_breakpoint@netflix.com"));
-    Alerting.SlackConfig bhSlack = new Alerting.SlackConfig();
-    bhSlack.setChannels(Collections.singleton("channel_breakpoint"));
-    bhType.setSlackConfig(bhSlack);
-    bhType.setActions(new HashSet<>(Arrays.asList(SLACK, EMAIL)));
-    bhType.setGranularity(AlertingTypeConfig.Granularity.STEP);
-
-    AlertingTypeConfig dcType = new AlertingTypeConfig();
-    dcType.setEmails(Collections.singleton("demo+alerting_wf_test_override_dc@netflix.com"));
-    Alerting.SlackConfig dcSlack = new Alerting.SlackConfig();
-    dcSlack.setUsers(new HashSet<>(Arrays.asList("defchange1", "defchange2")));
-    dcSlack.setChannels(Collections.singleton("channel_defchange"));
-    dcType.setSlackConfig(dcSlack);
-    dcType.setActions(Collections.singleton(SLACK));
-    dcType.setGranularity(AlertingTypeConfig.Granularity.WORKFLOW);
-
-    expected = new Alerting();
-    expected.setEmails(
-        new HashSet<>(
-            Arrays.asList(
-                "demo+alertconfig_default1@netflix.com", "demo+alertconfig_default2@netflix.com")));
-    expected.setPagerduties(new HashSet<>(Arrays.asList("default pager1", "default pager2")));
-    PagerdutyConfig pagerdutyConfig = new Alerting.PagerdutyConfig();
-    pagerdutyConfig.setAlwaysPage(true);
-    pagerdutyConfig.setSeverity(PagerdutyConfig.Severity.WARNING);
-    expected.setPagerdutyConfig(pagerdutyConfig);
-
-    Alerting.SlackConfig defaultSlack = new Alerting.SlackConfig();
-    defaultSlack.setChannels(
-        new HashSet<>(Arrays.asList("default_channel_1", "default_channel_2")));
-    defaultSlack.setUsers(new HashSet<>(Arrays.asList("defaultuser1", "defaultuser2")));
-    expected.setSlackConfig(defaultSlack);
-
-    BypassDigestConfig bdc = new BypassDigestConfig();
-    bdc.setBypassWorkflow(true);
-    bdc.setSteps(new HashSet<>(Arrays.asList("step1", "another_really_important_step")));
-    expected.setBypassDigestConfig(bdc);
-
-    expected.setTypeConfigs(new EnumMap<>(AlertType.class));
-    expected.getTypeConfigs().put(STEP_FAILURE, stepFailureType);
-    expected.getTypeConfigs().put(TCT_VIOLATION, tctType);
-    expected.getTypeConfigs().put(LONG_RUNNING, lrType);
-    expected.getTypeConfigs().put(BREAKPOINT_HIT, bhType);
-    expected.getTypeConfigs().put(DEFINITION_CHANGE, dcType);
-
-    Tct tct = new Tct();
-    tct.setCompletedByHour(1);
-    tct.setTz("UTC");
-    expected.setTct(tct);
+    @Override
+    public void update(Function<ParamDefinition, Parameter> paramParser) {}
   }
 
   @Test
-  public void testDeserialization() throws Exception {
-    final Alerting actual =
-        loadObject(
-            "fixtures/alerting/workflow_alerting_all_fields_overrides_payload.json",
-            Alerting.class);
-    assertEquals(expected, actual);
-    assertNull(actual.getTypeConfigs().get(STEP_FAILURE).getDurationMinutes());
+  public void defaultMapper_deserializesExistingJsonAsDefaultAlerting() throws Exception {
+    String json = "{\"emails\":[\"alice@example.com\"]}";
+    ObjectMapper mapper = JsonHelper.objectMapper();
+    Alerting parsed = mapper.readValue(json, Alerting.class);
+    assertTrue(parsed instanceof DefaultAlerting);
+    assertEquals(Set.of("alice@example.com"), ((DefaultAlerting) parsed).getEmails());
   }
 
   @Test
-  public void testSerde() throws Exception {
-    final Alerting reparsed = MAPPER.readValue(MAPPER.writeValueAsString(expected), Alerting.class);
-    assertEquals(expected, reparsed);
+  public void defaultMapper_serializedJsonHasNoExtraTypeField() throws Exception {
+    DefaultAlerting alerting = new DefaultAlerting();
+    alerting.setEmails(Set.of("alice@example.com"));
+    ObjectMapper mapper = JsonHelper.objectMapper();
+    String json = mapper.writeValueAsString(alerting);
+    assertFalse("JSON should not carry a type discriminator", json.contains("\"type\""));
   }
 
   @Test
-  public void testSerdeWithSuccessWithin() throws Exception {
-    AlertingTypeConfig config = new AlertingTypeConfig();
-    expected.getTypeConfigs().put(SUCCESS_WITHIN, config);
-    config.setDurationMinutes(2400);
-    config.setEmails(Collections.singleton("alertconfig_successwithin@netflix.com"));
-    config.setPagerduties(Collections.singleton("successwithin_pd"));
+  public void consumerMapping_overridesDefaultAlertingDeserialization() throws Exception {
+    ObjectMapper mapper = JsonHelper.objectMapper();
+    SimpleModule module = new SimpleModule();
+    module.addAbstractTypeMapping(Alerting.class, TestConsumerAlerting.class);
+    mapper.registerModule(module);
 
-    final Alerting reparsed = MAPPER.readValue(MAPPER.writeValueAsString(expected), Alerting.class);
-    assertEquals(expected, reparsed);
-  }
+    TestConsumerAlerting original = new TestConsumerAlerting();
+    original.setCustomField("hello");
+    String json = mapper.writeValueAsString(original);
+    Alerting parsed = mapper.readValue(json, Alerting.class);
 
-  @Test
-  public void testDeserializationWithSuccessWithin() throws Exception {
-    final Alerting actual =
-        loadObject(
-            "fixtures/alerting/workflow_alerting_with_success_within_payload.json", Alerting.class);
-    assertNotNull(actual.getTypeConfigs());
-    assertTrue(actual.getTypeConfigs().containsKey(SUCCESS_WITHIN));
-    AlertingTypeConfig config = actual.getTypeConfigs().get(SUCCESS_WITHIN);
-    assertEquals(1440, config.getDurationMinutes().intValue());
-  }
-
-  @Test
-  public void testAlertingUpdate() {
-    Alerting parsable = new Alerting();
-    parsable.setEmails(Set.of("${foo}", "${bar}"));
-    parsable.update(
-        paramDefinition -> {
-          Parameter param = paramDefinition.toParameter();
-          if (param.getValue().equals("${foo}")) {
-            param.setEvaluatedResult("test1@netflix.com");
-          } else {
-            return null;
-          }
-          param.setEvaluatedTime(1L);
-          return param;
-        });
-    assertEquals(Set.of("test1@netflix.com", "${bar}"), parsable.getEmails());
+    assertTrue(parsed instanceof TestConsumerAlerting);
+    assertEquals("hello", ((TestConsumerAlerting) parsed).getCustomField());
   }
 }

--- a/maestro-common/src/test/java/com/netflix/maestro/models/definition/DefaultAlertingTest.java
+++ b/maestro-common/src/test/java/com/netflix/maestro/models/definition/DefaultAlertingTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.maestro.models.definition;
+
+import static com.netflix.maestro.models.definition.alerting.AlertType.*;
+import static com.netflix.maestro.models.definition.alerting.AlertingTypeConfig.Action.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.netflix.maestro.MaestroBaseTest;
+import com.netflix.maestro.models.definition.DefaultAlerting.PagerdutyConfig;
+import com.netflix.maestro.models.definition.alerting.AlertType;
+import com.netflix.maestro.models.definition.alerting.AlertingTypeConfig;
+import com.netflix.maestro.models.definition.alerting.BypassDigestConfig;
+import com.netflix.maestro.models.parameter.Parameter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link DefaultAlerting}. */
+public class DefaultAlertingTest extends MaestroBaseTest {
+
+  private DefaultAlerting expected;
+
+  @Before
+  public void setupClass() {
+    AlertingTypeConfig stepFailureType = new AlertingTypeConfig();
+    stepFailureType.setEmails(Collections.singleton("demo+alertconfig_failure@netflix.com"));
+    stepFailureType.setPagerduties(Collections.singleton("alert config failure pager"));
+    DefaultAlerting.SlackConfig sfSlack = new DefaultAlerting.SlackConfig();
+    sfSlack.setChannels(Collections.singleton("channel_failure1"));
+    sfSlack.setUsers(Collections.singleton("failureuser"));
+    stepFailureType.setSlackConfig(sfSlack);
+    stepFailureType.setActions(new HashSet<>(Arrays.asList(EMAIL, PAGE, SLACK)));
+
+    AlertingTypeConfig tctType = new AlertingTypeConfig();
+    tctType.setEmails(Collections.singleton("demo+alertconfig_tct@netflix.com"));
+    tctType.setPagerduties(Collections.singleton("alert config tct pager"));
+    DefaultAlerting.SlackConfig tctSlack = new DefaultAlerting.SlackConfig();
+    tctSlack.setUsers(Collections.singleton("tctuser"));
+    tctSlack.setChannels(Collections.singleton("channel_tct"));
+    tctSlack.setMentionUsers(new HashSet<>(Arrays.asList("tct_mention1", "tct_mention2")));
+    tctType.setSlackConfig(tctSlack);
+    tctType.setActions(new HashSet<>(Arrays.asList(CANCEL, PAGE, SLACK)));
+
+    AlertingTypeConfig lrType = new AlertingTypeConfig();
+    lrType.setEmails(Collections.singleton("demo+alertconfig_longrunning@netflix.com"));
+    lrType.setPagerduties(Collections.singleton("alert config long running pager"));
+    DefaultAlerting.SlackConfig lrSlack = new DefaultAlerting.SlackConfig();
+    lrSlack.setUsers(Collections.singleton("longrunninguser"));
+    lrSlack.setChannels(
+        new HashSet<>(Arrays.asList("channel_longrunning1", "channel_longrunning2")));
+    lrType.setSlackConfig(lrSlack);
+    lrType.setActions(new HashSet<>(Arrays.asList(PAGE, EMAIL)));
+    lrType.setDisabled(true);
+    lrType.setGranularity(AlertingTypeConfig.Granularity.ALL);
+
+    AlertingTypeConfig bhType = new AlertingTypeConfig();
+    bhType.setEmails(Collections.singleton("demo+alertconfig_breakpoint@netflix.com"));
+    DefaultAlerting.SlackConfig bhSlack = new DefaultAlerting.SlackConfig();
+    bhSlack.setChannels(Collections.singleton("channel_breakpoint"));
+    bhType.setSlackConfig(bhSlack);
+    bhType.setActions(new HashSet<>(Arrays.asList(SLACK, EMAIL)));
+    bhType.setGranularity(AlertingTypeConfig.Granularity.STEP);
+
+    AlertingTypeConfig dcType = new AlertingTypeConfig();
+    dcType.setEmails(Collections.singleton("demo+alerting_wf_test_override_dc@netflix.com"));
+    DefaultAlerting.SlackConfig dcSlack = new DefaultAlerting.SlackConfig();
+    dcSlack.setUsers(new HashSet<>(Arrays.asList("defchange1", "defchange2")));
+    dcSlack.setChannels(Collections.singleton("channel_defchange"));
+    dcType.setSlackConfig(dcSlack);
+    dcType.setActions(Collections.singleton(SLACK));
+    dcType.setGranularity(AlertingTypeConfig.Granularity.WORKFLOW);
+
+    expected = new DefaultAlerting();
+    expected.setEmails(
+        new HashSet<>(
+            Arrays.asList(
+                "demo+alertconfig_default1@netflix.com", "demo+alertconfig_default2@netflix.com")));
+    expected.setPagerduties(new HashSet<>(Arrays.asList("default pager1", "default pager2")));
+    PagerdutyConfig pagerdutyConfig = new DefaultAlerting.PagerdutyConfig();
+    pagerdutyConfig.setAlwaysPage(true);
+    pagerdutyConfig.setSeverity(PagerdutyConfig.Severity.WARNING);
+    expected.setPagerdutyConfig(pagerdutyConfig);
+
+    DefaultAlerting.SlackConfig defaultSlack = new DefaultAlerting.SlackConfig();
+    defaultSlack.setChannels(
+        new HashSet<>(Arrays.asList("default_channel_1", "default_channel_2")));
+    defaultSlack.setUsers(new HashSet<>(Arrays.asList("defaultuser1", "defaultuser2")));
+    expected.setSlackConfig(defaultSlack);
+
+    BypassDigestConfig bdc = new BypassDigestConfig();
+    bdc.setBypassWorkflow(true);
+    bdc.setSteps(new HashSet<>(Arrays.asList("step1", "another_really_important_step")));
+    expected.setBypassDigestConfig(bdc);
+
+    expected.setTypeConfigs(new EnumMap<>(AlertType.class));
+    expected.getTypeConfigs().put(STEP_FAILURE, stepFailureType);
+    expected.getTypeConfigs().put(TCT_VIOLATION, tctType);
+    expected.getTypeConfigs().put(LONG_RUNNING, lrType);
+    expected.getTypeConfigs().put(BREAKPOINT_HIT, bhType);
+    expected.getTypeConfigs().put(DEFINITION_CHANGE, dcType);
+
+    Tct tct = new Tct();
+    tct.setCompletedByHour(1);
+    tct.setTz("UTC");
+    expected.setTct(tct);
+  }
+
+  @Test
+  public void testDeserialization() throws Exception {
+    final DefaultAlerting actual =
+        loadObject(
+            "fixtures/alerting/workflow_alerting_all_fields_overrides_payload.json",
+            DefaultAlerting.class);
+    assertEquals(expected, actual);
+    assertNull(actual.getTypeConfigs().get(STEP_FAILURE).getDurationMinutes());
+  }
+
+  @Test
+  public void testSerde() throws Exception {
+    final DefaultAlerting reparsed =
+        MAPPER.readValue(MAPPER.writeValueAsString(expected), DefaultAlerting.class);
+    assertEquals(expected, reparsed);
+  }
+
+  @Test
+  public void testSerdeWithSuccessWithin() throws Exception {
+    AlertingTypeConfig config = new AlertingTypeConfig();
+    expected.getTypeConfigs().put(SUCCESS_WITHIN, config);
+    config.setDurationMinutes(2400);
+    config.setEmails(Collections.singleton("alertconfig_successwithin@netflix.com"));
+    config.setPagerduties(Collections.singleton("successwithin_pd"));
+
+    final DefaultAlerting reparsed =
+        MAPPER.readValue(MAPPER.writeValueAsString(expected), DefaultAlerting.class);
+    assertEquals(expected, reparsed);
+  }
+
+  @Test
+  public void testDeserializationWithSuccessWithin() throws Exception {
+    final DefaultAlerting actual =
+        loadObject(
+            "fixtures/alerting/workflow_alerting_with_success_within_payload.json",
+            DefaultAlerting.class);
+    assertNotNull(actual.getTypeConfigs());
+    assertTrue(actual.getTypeConfigs().containsKey(SUCCESS_WITHIN));
+    AlertingTypeConfig config = actual.getTypeConfigs().get(SUCCESS_WITHIN);
+    assertEquals(1440, config.getDurationMinutes().intValue());
+  }
+
+  @Test
+  public void testDefaultAlertingUpdate() {
+    DefaultAlerting parsable = new DefaultAlerting();
+    parsable.setEmails(Set.of("${foo}", "${bar}"));
+    parsable.update(
+        paramDefinition -> {
+          Parameter param = paramDefinition.toParameter();
+          if (param.getValue().equals("${foo}")) {
+            param.setEvaluatedResult("test1@netflix.com");
+          } else {
+            return null;
+          }
+          param.setEvaluatedTime(1L);
+          return param;
+        });
+    assertEquals(Set.of("test1@netflix.com", "${bar}"), parsable.getEmails());
+  }
+}

--- a/maestro-common/src/test/java/com/netflix/maestro/models/definition/DefaultAlertingTest.java
+++ b/maestro-common/src/test/java/com/netflix/maestro/models/definition/DefaultAlertingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Netflix, Inc.
+ * Copyright 2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroWorkflowDaoTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroWorkflowDaoTest.java
@@ -39,6 +39,7 @@ import com.netflix.maestro.exceptions.MaestroUnprocessableEntityException;
 import com.netflix.maestro.models.Constants;
 import com.netflix.maestro.models.Defaults;
 import com.netflix.maestro.models.api.WorkflowOverviewResponse;
+import com.netflix.maestro.models.definition.DefaultAlerting;
 import com.netflix.maestro.models.definition.Metadata;
 import com.netflix.maestro.models.definition.Properties;
 import com.netflix.maestro.models.definition.PropertiesSnapshot;
@@ -1005,7 +1006,8 @@ public class MaestroWorkflowDaoTest extends MaestroDaoBaseTest {
     assertEquals(RunStrategy.Rule.PARALLEL, snapshot.getRunStrategy().getRule());
     assertEquals(20, snapshot.getRunStrategy().getWorkflowConcurrency());
     assertEquals(20, snapshot.getStepConcurrency().longValue());
-    assertEquals(1, snapshot.getAlerting().getTct().getCompletedByHour().intValue());
+    assertEquals(
+        1, ((DefaultAlerting) snapshot.getAlerting()).getTct().getCompletedByHour().intValue());
   }
 
   @Test
@@ -1032,7 +1034,8 @@ public class MaestroWorkflowDaoTest extends MaestroDaoBaseTest {
     assertEquals(RunStrategy.Rule.PARALLEL, snapshot.getRunStrategy().getRule());
     assertEquals(20, snapshot.getRunStrategy().getWorkflowConcurrency());
     assertEquals(20, snapshot.getStepConcurrency().longValue());
-    assertEquals(1, snapshot.getAlerting().getTct().getCompletedByHour().intValue());
+    assertEquals(
+        1, ((DefaultAlerting) snapshot.getAlerting()).getTct().getCompletedByHour().intValue());
 
     assertEquals(wfd.getPropertiesSnapshot(), snapshot);
 

--- a/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/DefaultAlertingNotebookParamsContributor.java
+++ b/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/DefaultAlertingNotebookParamsContributor.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.maestro.engine.notebook;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.maestro.engine.execution.WorkflowSummary;
+import com.netflix.maestro.exceptions.MaestroBadRequestException;
+import com.netflix.maestro.models.definition.Alerting;
+import com.netflix.maestro.models.definition.DefaultAlerting;
+import com.netflix.maestro.models.definition.Tct;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link NotebookParamsContributor} that surfaces the {@link DefaultAlerting} shape (emails,
+ * pagerduties, slack, tct) into notebook params. Noops if the workflow's alerting block is null or
+ * a non-default {@link Alerting} implementation.
+ */
+@Slf4j
+@AllArgsConstructor
+public class DefaultAlertingNotebookParamsContributor implements NotebookParamsContributor {
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void contribute(WorkflowSummary summary, Map<String, Object> paramMap) {
+    Alerting alerting = summary.getRunProperties().getAlerting();
+    if (!(alerting instanceof DefaultAlerting defaultAlerting)) {
+      return;
+    }
+    addTctParamsIfPresent(paramMap, defaultAlerting);
+    Set<String> pagerDuties = defaultAlerting.getPagerduties();
+    Set<String> emails = defaultAlerting.getEmails();
+    if (pagerDuties != null && !pagerDuties.isEmpty()) {
+      paramMap.put(NotebookConstants.PAGER_DUTIES, pagerDuties);
+    }
+    if (emails != null && !emails.isEmpty()) {
+      paramMap.put(NotebookConstants.NOTIFICATION_EMAILS, emails);
+    }
+    DefaultAlerting.SlackConfig slackConfig = defaultAlerting.getSlackConfig();
+    if (slackConfig != null) {
+      addSlackParamsIfPresent(summary, paramMap, slackConfig);
+    }
+  }
+
+  private void addSlackParamsIfPresent(
+      WorkflowSummary summary,
+      Map<String, Object> paramMap,
+      DefaultAlerting.SlackConfig slackConfig) {
+    Map<String, String> slackParams = new LinkedHashMap<>();
+    Set<String> users = slackConfig.getUsers();
+    try {
+      if (users != null && !users.isEmpty()) {
+        slackParams.put(NotebookConstants.SLACK_USERS, objectMapper.writeValueAsString(users));
+      }
+      Set<String> channels = slackConfig.getChannels();
+      if (channels != null && !channels.isEmpty()) {
+        slackParams.put(
+            NotebookConstants.SLACK_CHANNELS, objectMapper.writeValueAsString(channels));
+      }
+    } catch (JsonProcessingException e) {
+      String workflowIdentity = summary.getIdentity();
+      LOG.warn("Failed to serialize slack params for workflow {}", workflowIdentity, e);
+      throw new MaestroBadRequestException(
+          e, "Failed to serialize slack params for workflow %s", workflowIdentity);
+    }
+    if (!slackParams.isEmpty()) {
+      paramMap.put(NotebookConstants.SLACK_PARAM, slackParams);
+    }
+  }
+
+  private void addTctParamsIfPresent(Map<String, Object> paramMap, DefaultAlerting alerting) {
+    Tct tct = alerting.getTct();
+    if (tct == null) {
+      return;
+    }
+    Map<String, String> tctMap = new LinkedHashMap<>();
+    if (tct.getCompletedByHour() != null) {
+      tctMap.put(NotebookConstants.TCT_COMPLETED_BY_HOUR, tct.getCompletedByHour().toString());
+    }
+    if (tct.getDurationMinutes() != null) {
+      tctMap.put(NotebookConstants.TCT_DURATION_MINUTES, tct.getDurationMinutes().toString());
+    }
+    if (tct.getCompletedByTs() != null) {
+      tctMap.put(NotebookConstants.TCT_COMPLETED_BY_TS, tct.getCompletedByTs().toString());
+    }
+    if (tct.getTz() != null) {
+      tctMap.put(NotebookConstants.TCT_TZ, tct.getTz());
+    }
+    if (!tctMap.isEmpty()) {
+      paramMap.put(NotebookConstants.TCT_PARAM, tctMap);
+    }
+  }
+}

--- a/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/DefaultAlertingNotebookParamsContributor.java
+++ b/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/DefaultAlertingNotebookParamsContributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Netflix, Inc.
+ * Copyright 2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/NotebookParamsBuilder.java
+++ b/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/NotebookParamsBuilder.java
@@ -18,14 +18,13 @@ import com.netflix.maestro.engine.execution.StepRuntimeSummary;
 import com.netflix.maestro.engine.execution.WorkflowSummary;
 import com.netflix.maestro.exceptions.MaestroBadRequestException;
 import com.netflix.maestro.models.Constants;
-import com.netflix.maestro.models.definition.Alerting;
 import com.netflix.maestro.models.definition.Step;
-import com.netflix.maestro.models.definition.Tct;
 import com.netflix.maestro.models.parameter.ParamType;
 import com.netflix.maestro.models.parameter.Parameter;
 import com.netflix.maestro.utils.Checks;
 import com.netflix.maestro.utils.MapHelper;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +50,7 @@ public class NotebookParamsBuilder {
           Constants.INITIATOR_TIMEZONE_PARAM);
 
   private final ObjectMapper objectMapper;
+  private final List<NotebookParamsContributor> contributors;
 
   /**
    * Build notebook parameters and return the full JSON string.
@@ -73,82 +73,14 @@ public class NotebookParamsBuilder {
           workflowSummary.getCriticality().name().toLowerCase(Locale.US));
     }
     paramMap.put(NotebookConstants.ATTEMPT_NUMBER, runtimeSummary.getStepAttemptId() - 1);
-    addAlertingParamsIfPresent(paramMap, workflowSummary);
+    for (NotebookParamsContributor contributor : contributors) {
+      contributor.contribute(workflowSummary, paramMap);
+    }
 
     Map<String, Object> extraPapermillParams = generatePapermillParams(workflowSummary);
     paramMap.putAll(extraPapermillParams);
 
     return toPapermillParams(workflowSummary, paramMap);
-  }
-
-  private void addAlertingParamsIfPresent(
-      Map<String, Object> paramMap, WorkflowSummary workflowSummary) {
-    Alerting alerting = workflowSummary.getRunProperties().getAlerting();
-    if (alerting == null) {
-      return;
-    }
-    addTctParamsIfPresent(paramMap, alerting);
-    Set<String> pagerDuties = alerting.getPagerduties();
-    Set<String> emails = alerting.getEmails();
-    if (pagerDuties != null && !pagerDuties.isEmpty()) {
-      paramMap.put(NotebookConstants.PAGER_DUTIES, pagerDuties);
-    }
-    if (emails != null && !emails.isEmpty()) {
-      paramMap.put(NotebookConstants.NOTIFICATION_EMAILS, emails);
-    }
-    Alerting.SlackConfig slackConfig = alerting.getSlackConfig();
-    if (slackConfig != null) {
-      addSlackParamsIfPresent(workflowSummary, paramMap, slackConfig);
-    }
-  }
-
-  private void addSlackParamsIfPresent(
-      WorkflowSummary workflowSummary,
-      Map<String, Object> paramMap,
-      Alerting.SlackConfig slackConfig) {
-    Map<String, String> slackParams = new LinkedHashMap<>();
-    Set<String> users = slackConfig.getUsers();
-    try {
-      if (users != null && !users.isEmpty()) {
-        slackParams.put(NotebookConstants.SLACK_USERS, objectMapper.writeValueAsString(users));
-      }
-      Set<String> channels = slackConfig.getChannels();
-      if (channels != null && !channels.isEmpty()) {
-        slackParams.put(
-            NotebookConstants.SLACK_CHANNELS, objectMapper.writeValueAsString(channels));
-      }
-    } catch (JsonProcessingException e) {
-      String workflowIdentity = workflowSummary.getIdentity();
-      LOG.warn("Failed to serialize slack params for workflow {}", workflowIdentity, e);
-      throw new MaestroBadRequestException(
-          e, "Failed to serialize slack params for workflow %s", workflowIdentity);
-    }
-    if (!slackParams.isEmpty()) {
-      paramMap.put(NotebookConstants.SLACK_PARAM, slackParams);
-    }
-  }
-
-  private void addTctParamsIfPresent(Map<String, Object> paramMap, Alerting alerting) {
-    Tct tct = alerting.getTct();
-    if (tct == null) {
-      return;
-    }
-    Map<String, String> tctMap = new LinkedHashMap<>();
-    if (tct.getCompletedByHour() != null) {
-      tctMap.put(NotebookConstants.TCT_COMPLETED_BY_HOUR, tct.getCompletedByHour().toString());
-    }
-    if (tct.getDurationMinutes() != null) {
-      tctMap.put(NotebookConstants.TCT_DURATION_MINUTES, tct.getDurationMinutes().toString());
-    }
-    if (tct.getCompletedByTs() != null) {
-      tctMap.put(NotebookConstants.TCT_COMPLETED_BY_TS, tct.getCompletedByTs().toString());
-    }
-    if (tct.getTz() != null) {
-      tctMap.put(NotebookConstants.TCT_TZ, tct.getTz());
-    }
-    if (!tctMap.isEmpty()) {
-      paramMap.put(NotebookConstants.TCT_PARAM, tctMap);
-    }
   }
 
   /**

--- a/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/NotebookParamsContributor.java
+++ b/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/NotebookParamsContributor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Netflix, Inc.
+ * Copyright 2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -19,10 +19,12 @@ import java.util.Map;
  * SPI that lets consumers contribute extra entries to the notebook param map alongside the standard
  * parameters built by {@link NotebookParamsBuilder}.
  *
- * <p>{@link NotebookParamsBuilder} invokes every registered contributor in injection order. A
- * contributor may noop when the workflow's properties don't carry the shape it understands (typical
- * for alerting-driven contributors that only handle one concrete {@link
- * com.netflix.maestro.models.definition.Alerting} implementation).
+ * <p>{@link NotebookParamsBuilder} invokes every registered contributor. The invocation order
+ * follows the injected {@code List} order, which Spring does not strongly guarantee, so
+ * contributors should write disjoint keys; if two contributors write the same key the result
+ * depends on ordering and is effectively undefined. A contributor may noop when the workflow's
+ * properties don't carry the shape it understands (typical for alerting-driven contributors that
+ * only handle one concrete {@link com.netflix.maestro.models.definition.Alerting} implementation).
  *
  * <p>Contributors own their own dependencies (e.g., an {@code ObjectMapper} for nested JSON
  * serialization); the SPI itself stays narrow on purpose.

--- a/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/NotebookParamsContributor.java
+++ b/maestro-kubernetes/src/main/java/com/netflix/maestro/engine/notebook/NotebookParamsContributor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.maestro.engine.notebook;
+
+import com.netflix.maestro.engine.execution.WorkflowSummary;
+import java.util.Map;
+
+/**
+ * SPI that lets consumers contribute extra entries to the notebook param map alongside the standard
+ * parameters built by {@link NotebookParamsBuilder}.
+ *
+ * <p>{@link NotebookParamsBuilder} invokes every registered contributor in injection order. A
+ * contributor may noop when the workflow's properties don't carry the shape it understands (typical
+ * for alerting-driven contributors that only handle one concrete {@link
+ * com.netflix.maestro.models.definition.Alerting} implementation).
+ *
+ * <p>Contributors own their own dependencies (e.g., an {@code ObjectMapper} for nested JSON
+ * serialization); the SPI itself stays narrow on purpose.
+ */
+@FunctionalInterface
+public interface NotebookParamsContributor {
+  /**
+   * Contribute zero or more entries to the notebook param map.
+   *
+   * @param summary the workflow summary providing properties, params, and identity
+   * @param paramMap mutable map that will be serialized as the notebook param payload
+   */
+  void contribute(WorkflowSummary summary, Map<String, Object> paramMap);
+}

--- a/maestro-kubernetes/src/test/java/com/netflix/maestro/engine/notebook/NotebookParamsBuilderTest.java
+++ b/maestro-kubernetes/src/test/java/com/netflix/maestro/engine/notebook/NotebookParamsBuilderTest.java
@@ -28,6 +28,7 @@ import com.netflix.maestro.models.parameter.Parameter;
 import com.netflix.maestro.models.parameter.StringParamDefinition;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,7 +42,9 @@ public class NotebookParamsBuilderTest extends MaestroBaseTest {
 
   @Before
   public void before() {
-    notebookParamsBuilder = new NotebookParamsBuilder(MAPPER);
+    notebookParamsBuilder =
+        new NotebookParamsBuilder(
+            MAPPER, List.of(new DefaultAlertingNotebookParamsContributor(MAPPER)));
     workflowParams = new LinkedHashMap<>();
     workflowSummary = new WorkflowSummary();
     workflowSummary.setWorkflowRunId(2);

--- a/maestro-kubernetes/src/test/java/com/netflix/maestro/engine/notebook/PapermillEntrypointBuilderTest.java
+++ b/maestro-kubernetes/src/test/java/com/netflix/maestro/engine/notebook/PapermillEntrypointBuilderTest.java
@@ -32,6 +32,7 @@ import com.netflix.maestro.models.parameter.ParamDefinition;
 import com.netflix.maestro.models.parameter.Parameter;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -87,7 +88,10 @@ public class PapermillEntrypointBuilderTest extends MaestroBaseTest {
             .subType("SparkJob")
             .build();
     context = new KubernetesStepContext(workflowSummary, stepRuntimeSummary, null);
-    papermillEntrypointBuilder = new PapermillEntrypointBuilder(new NotebookParamsBuilder(MAPPER));
+    papermillEntrypointBuilder =
+        new PapermillEntrypointBuilder(
+            new NotebookParamsBuilder(
+                MAPPER, List.of(new DefaultAlertingNotebookParamsContributor(MAPPER))));
   }
 
   @Test

--- a/maestro-server/src/main/java/com/netflix/maestro/server/config/MaestroStepRuntimeConfiguration.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/config/MaestroStepRuntimeConfiguration.java
@@ -31,7 +31,9 @@ import com.netflix.maestro.engine.http.SizeBoundedBodyHandler;
 import com.netflix.maestro.engine.http.UrlValidator;
 import com.netflix.maestro.engine.kubernetes.KubernetesCommandGenerator;
 import com.netflix.maestro.engine.kubernetes.KubernetesRuntimeExecutor;
+import com.netflix.maestro.engine.notebook.DefaultAlertingNotebookParamsContributor;
 import com.netflix.maestro.engine.notebook.NotebookParamsBuilder;
+import com.netflix.maestro.engine.notebook.NotebookParamsContributor;
 import com.netflix.maestro.engine.notebook.PapermillEntrypointBuilder;
 import com.netflix.maestro.engine.params.DefaultParamManager;
 import com.netflix.maestro.engine.params.OutputDataManager;
@@ -63,6 +65,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -161,10 +164,17 @@ public class MaestroStepRuntimeConfiguration {
   }
 
   @Bean
-  public NotebookParamsBuilder notebookParamsBuilder(
+  public NotebookParamsContributor defaultAlertingNotebookParamsContributor(
       @Qualifier(Constants.MAESTRO_QUALIFIER) ObjectMapper objectMapper) {
+    return new DefaultAlertingNotebookParamsContributor(objectMapper);
+  }
+
+  @Bean
+  public NotebookParamsBuilder notebookParamsBuilder(
+      @Qualifier(Constants.MAESTRO_QUALIFIER) ObjectMapper objectMapper,
+      List<NotebookParamsContributor> contributors) {
     LOG.info("Creating notebookParamsBuilder within Spring boot...");
-    return new NotebookParamsBuilder(objectMapper);
+    return new NotebookParamsBuilder(objectMapper, contributors);
   }
 
   @Bean


### PR DESCRIPTION
## Make `Properties.alerting` a pluggable interface

The `Properties.alerting` field is currently a concrete `Alerting` POJO with a Netflix-specific shape (`emails`, `pagerduties`, `slackConfig`, `bypassDigestConfig`, `typeConfigs<AlertType, AlertingTypeConfig>`, `pagerdutyConfig`, `tct`).

The engine itself only invokes `Alerting.update(paramParser)` for `${...}` template interpolation in `emails` and `tct.completedByTs`. The rest of the fields are metadata that downstream systems interpret. The detection/alerting impl that consumes these fields lives outside Maestro entirely, so the specific shape is largely irrelevant to the engine.

This PR:

1. Extracts a new `Alerting` interface in `com.netflix.maestro.models.definition` with the single method `update(Function<ParamDefinition, Parameter> paramParser)`.
2. Renames the existing `Alerting` class to `DefaultAlerting` (same package), implementing `Alerting`. All fields, annotations, and inner classes (`SlackConfig`, `PagerdutyConfig`) are preserved.
3. Wires `JsonHelper.objectMapper()` to register `DefaultAlerting` as the abstract-type mapping for `Alerting`, via `SimpleModule.addAbstractTypeMapping(...)` inside `configureMapper`. The OSS-default mapper continues to deserialize the alerting block to `DefaultAlerting` exactly as before.
4. Updates `AlertingTypeConfig` (one nested `SlackConfig` ref) and tests to use `DefaultAlerting` where concrete-field access is needed.

No `@JsonTypeInfo` discriminator is used. Each running JVM uses exactly one `Alerting` implementation, so a discriminator would add a `"type"` field to every serialized payload without runtime value. Mapper-level abstract-type mapping is sufficient.

### `NotebookParamsContributor` SPI

`NotebookParamsBuilder` previously read `pagerduties`/`emails`/`slackConfig`/`tct` directly off `Alerting` to surface them as papermill params, so any consumer with a different alerting shape would have to fork the builder.

This PR extracts a small SPI:

- New `NotebookParamsContributor` interface: `void contribute(WorkflowSummary, Map<String,Object> paramMap)`.
- The existing alerting → notebook-param logic moves into `DefaultAlertingNotebookParamsContributor`, which owns its own `ObjectMapper` and noops on non-default `Alerting` impls.
- `NotebookParamsBuilder` now takes `List<NotebookParamsContributor>` and iterates. Spring composes contributors from any beans of that type, so a downstream consumer can register their own `@Component implements NotebookParamsContributor` without subclassing the builder.

### Behavior preserved

- All existing serialized JSON deserializes identically (as `DefaultAlerting`).
- Serialized JSON contains no new fields (no `type` discriminator).
- All existing engine code paths invoke the same logic via the interface method (`Alerting.update(...)` → `DefaultAlerting.update(...)`).
- Notebook param output is unchanged for `DefaultAlerting`.
- All existing tests pass.

### Behavior added

- Downstream consumers can swap in their own `Alerting` POJO by registering a `SimpleModule` with their `ObjectMapper`:
  ```java
  SimpleModule module = new SimpleModule();
  module.addAbstractTypeMapping(Alerting.class, MyAlerting.class);
  mapper.registerModule(module);
  ```
  Subsequent deserialization of the alerting field on `Properties` / `RunProperties` / `PropertiesSnapshot` will produce a `MyAlerting` instance.
- Downstream consumers can register their own `NotebookParamsContributor` bean to surface their alerting fields (or any other `WorkflowSummary`-derived data) into notebook params alongside the OSS default.

### Tests

- `DefaultAlertingTest` (the renamed pre-existing `AlertingTest`) continues to cover the concrete-impl behavior.
- New `AlertingTest` covers the interface-level behavior:
  - default-mapper resolves `Alerting` to `DefaultAlerting` and deserializes existing JSON unchanged
  - serialized JSON contains no extra `type` field
  - consumer abstract-type-mapping override round-trips through a custom `Alerting` impl

## Test plan

- [x] `./gradlew build` passes from a clean state
- [x] All existing tests pass
- [x] New `AlertingTest` covers interface contract
- [x] `NotebookParamsBuilderTest` and `PapermillEntrypointBuilderTest` updated to inject the default contributor