### PR TITLE
Implement SERIAL_LATEST_ONLY run strategy

### DIFF
--- a/maestro-common/src/main/java/com/netflix/maestro/models/definition/RunStrategy.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/definition/RunStrategy.java
@@ -73,9 +73,10 @@ public class RunStrategy {
      */
     PARALLEL,
     /**
-     * SERIAL_LATEST_ONLY: run workflow instances one at a time and, when the running instance
-     * reaches a terminal state, only the latest queued instance is dequeued to run while every
-     * older queued instance is stopped. The running instance is never terminated by a new arrival.
+     * SERIAL_LATEST_ONLY: run workflow instances one at a time. When a new instance arrives, any
+     * existing queued instance is stopped eagerly so only the new arrival is queued. When the
+     * running instance reaches a terminal state, the single queued instance is dequeued to run. The
+     * running instance is never terminated by a new arrival.
      */
     SERIAL_LATEST_ONLY;
 

--- a/maestro-common/src/main/java/com/netflix/maestro/models/definition/RunStrategy.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/definition/RunStrategy.java
@@ -71,7 +71,13 @@ public class RunStrategy {
      * PARALLEL: run all triggered workflows in parallel constrained by the workflow concurrency
      * setting.
      */
-    PARALLEL;
+    PARALLEL,
+    /**
+     * SERIAL_LATEST_ONLY: run workflow instances one at a time and, when the running instance
+     * reaches a terminal state, only the latest queued instance is dequeued to run while every
+     * older queued instance is stopped. The running instance is never terminated by a new arrival.
+     */
+    SERIAL_LATEST_ONLY;
 
     /** Static creator. */
     @JsonCreator

--- a/maestro-common/src/test/java/com/netflix/maestro/models/definition/RunStrategyTest.java
+++ b/maestro-common/src/test/java/com/netflix/maestro/models/definition/RunStrategyTest.java
@@ -41,10 +41,14 @@ public class RunStrategyTest extends MaestroBaseTest {
           "{\"run_strategy\": {\"rule\": \"parallel\", \"workflow_concurrency\": 2}}",
           "{\"run_strategy\": {\"rule\": \"parallel\", \"workflow_concurrency\": 1}}",
           "{\"run_strategy\": {\"rule\": \"parallel\", \"workflow_concurrency\": 0}}",
-          "{\"run_strategy\": {\"rule\": \"sequential\"}}");
+          "{\"run_strategy\": {\"rule\": \"sequential\"}}",
+          "{\"run_strategy\": \"SERIAL_LATEST_ONLY\"}",
+          "{\"run_strategy\": \"serial_latest_only\"}",
+          "{\"run_strategy\": {\"rule\": \"SERIAL_LATEST_ONLY\", \"workflow_concurrency\": 1}}");
 
   private final List<Long> validCaseConcurrency =
-      Arrays.asList(1L, 1L, 1L, 1L, Defaults.DEFAULT_PARALLELISM, 0L, 1L, 2L, 1L, 2L, 1L, 0L, 1L);
+      Arrays.asList(
+          1L, 1L, 1L, 1L, Defaults.DEFAULT_PARALLELISM, 0L, 1L, 2L, 1L, 2L, 1L, 0L, 1L, 1L, 1L, 1L);
 
   private final List<String[]> invalidCases =
       Arrays.asList(
@@ -66,6 +70,10 @@ public class RunStrategyTest extends MaestroBaseTest {
           },
           new String[] {
             "{\"run_strategy\": {\"rule\": \"LAST_ONLY\", \"workflow_concurrency\": 2}}",
+            "Only PARALLEL run strategy allows a workflow_concurrency greater than 1 "
+          },
+          new String[] {
+            "{\"run_strategy\": {\"rule\": \"SERIAL_LATEST_ONLY\", \"workflow_concurrency\": 2}}",
             "Only PARALLEL run strategy allows a workflow_concurrency greater than 1 "
           });
 

--- a/maestro-common/src/testFixtures/resources/fixtures/workflows/definition/sample-minimal-wf-run-strategy-serial-latest-only.json
+++ b/maestro-common/src/testFixtures/resources/fixtures/workflows/definition/sample-minimal-wf-run-strategy-serial-latest-only.json
@@ -1,0 +1,34 @@
+{
+  "properties_snapshot": {
+    "owner": "tester",
+    "run_strategy": "SERIAL_LATEST_ONLY"
+  },
+  "is_active": true,
+  "activate_time": 1598399975650,
+  "activated_by": "demo",
+  "is_default": true,
+  "modify_time": 1598399975650,
+  "metadata": {
+    "workflow_id": "sample-minimal-wf-run-strategy-serial-latest-only",
+    "create_time": 1598399975650,
+    "version_author": "demo"
+  },
+  "workflow": {
+    "id": "sample-minimal-wf-run-strategy-serial-latest-only",
+    "steps": [
+      {
+        "step": {
+          "id": "job1",
+          "type": "Sleep",
+          "params": {
+            "sleep_seconds": {
+              "value": 180,
+              "type": "LONG",
+              "mode": "MUTABLE"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDao.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDao.java
@@ -683,6 +683,7 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
             case SEQUENTIAL:
             case PARALLEL:
             case STRICT_SEQUENTIAL:
+            case SERIAL_LATEST_ONLY:
               return dequeueWorkflowInstances(
                   workflowId,
                   runStrategy.getWorkflowConcurrency(),
@@ -690,8 +691,6 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
             case FIRST_ONLY:
             case LAST_ONLY:
               return null; // no queueing support
-            case SERIAL_LATEST_ONLY:
-              return dequeueWorkflowInstances(workflowId, 1, false);
             default:
               throw new MaestroInternalError(
                   "When dequeue, run strategy [%s] hasn't been implemented yet", runStrategy);

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDao.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDao.java
@@ -55,9 +55,9 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Workflow run strategy manager to handle starting workflow instance runs. It supports starting or
  * running instances by any maestro initiators, including manual, signal, time, and subworkflow
- * trigger. Five run strategy rules are implemented. Three of them (sequential, parallel,
- * strict_sequential) support queueing. Two of them (first_only and last_only) do not allow queueing
- * and the decision (start/stop) is made when the request is received.
+ * trigger. Six run strategy rules are implemented. Four of them (sequential, parallel,
+ * strict_sequential, serial_latest_only) support queueing. Two of them (first_only and last_only)
+ * do not allow queueing and the decision (start/stop) is made when the request is received.
  *
  * <p>If queueing is enabled, at the end, a {@link StartWorkflowJobEvent} event is emitted. If
  * disabling queueing, at the end, emit a {@link TerminateThenRunJobEvent} event if feasible.
@@ -140,6 +140,14 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
   private static final String LAST_ONLY_TIMELINE_TEMPLATE =
       "[\"With LAST_ONLY run strategy, this run is stopped due to starting a new run.\"]";
 
+  private static final String SERIAL_LATEST_ONLY_TIMELINE_TEMPLATE =
+      "[\"With SERIAL_LATEST_ONLY run strategy, this run is stopped because new instance %s with run %s arrived.\"]";
+
+  private static final String STOP_SERIAL_LATEST_ONLY_QUEUED_INSTANCE_QUERY =
+      "UPDATE maestro_workflow_instance SET status = 'STOPPED', "
+          + "end_ts = CURRENT_TIMESTAMP, modify_ts = CURRENT_TIMESTAMP, timeline = array_append(timeline, ?) "
+          + "WHERE workflow_id=? AND status='CREATED' AND execution_id IS NULL RETURNING instance";
+
   private static final String STOP_QUEUED_INSTANCES_QUERY =
       "UPDATE maestro_workflow_instance SET status = 'STOPPED', start_ts = CURRENT_TIMESTAMP, "
           + "end_ts = CURRENT_TIMESTAMP, modify_ts = CURRENT_TIMESTAMP, timeline = array_append(timeline, ?) "
@@ -158,7 +166,10 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
           + "WHERE workflow_id=? AND instance_id=? AND run_id<? AND status='FAILED'";
 
   private static final Set<RunStrategy.Rule> SERIALIZABLE_RUN_STRATEGIES =
-      Set.of(RunStrategy.Rule.FIRST_ONLY, RunStrategy.Rule.LAST_ONLY);
+      Set.of(
+          RunStrategy.Rule.FIRST_ONLY,
+          RunStrategy.Rule.LAST_ONLY,
+          RunStrategy.Rule.SERIAL_LATEST_ONLY);
 
   private static final String RUN_STRATEGY_TAG = "run_strategy";
   private static final User RUN_STRATEGY_USER =
@@ -628,6 +639,9 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
                           case LAST_ONLY:
                             res = startLastOnlyInstance(conn, attemptInstance, messages);
                             break;
+                          case SERIAL_LATEST_ONLY:
+                            res = startSerialLatestOnlyInstance(conn, attemptInstance, messages);
+                            break;
                           default:
                             throw new MaestroInternalError(
                                 "When start, run strategy [%s] is not supported.", runStrategy);
@@ -676,6 +690,8 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
             case FIRST_ONLY:
             case LAST_ONLY:
               return null; // no queueing support
+            case SERIAL_LATEST_ONLY:
+              return dequeueWorkflowInstances(workflowId, 1, false);
             default:
               throw new MaestroInternalError(
                   "When dequeue, run strategy [%s] hasn't been implemented yet", runStrategy);
@@ -782,6 +798,11 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
                         case LAST_ONLY:
                           res =
                               startLastOnlyInstances(conn, workflowId, attemptInstances, messages);
+                          break;
+                        case SERIAL_LATEST_ONLY:
+                          res =
+                              startSerialLatestOnlyInstances(
+                                  conn, workflowId, attemptInstances, messages);
                           break;
                         default:
                           throw new MaestroInternalError(
@@ -905,6 +926,138 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
     }
     Collections.reverse(instances);
     return ret;
+  }
+
+  private int startSerialLatestOnlyInstance(
+      Connection conn, WorkflowInstance instance, List<MessageDto> messages) throws SQLException {
+    stopSerialLatestOnlyQueuedInstance(
+        conn,
+        instance.getWorkflowId(),
+        instance.getWorkflowInstanceId(),
+        instance.getWorkflowRunId(),
+        messages);
+    return insertInstance(conn, instance, true, null, messages);
+  }
+
+  private int[] startSerialLatestOnlyInstances(
+      Connection conn,
+      String workflowId,
+      List<WorkflowInstance> instances,
+      List<MessageDto> messages)
+      throws SQLException {
+    Collections.reverse(instances);
+    int[] ret = new int[instances.size()];
+    List<WorkflowInstance> stoppedInstances = new ArrayList<>();
+    long newInstanceId = 0;
+    long newRunId = 0;
+    TimelineEvent timelineEvent = null;
+    boolean firstInserted = false;
+
+    // scan to find the new arrival identity before touching the DB
+    for (WorkflowInstance inst : instances) {
+      if (inst.getWorkflowInstanceId() != DO_NOTHING_CODE) {
+        newInstanceId = inst.getWorkflowInstanceId();
+        newRunId = inst.getWorkflowRunId();
+        timelineEvent =
+            TimelineLogEvent.info(SERIAL_LATEST_ONLY_TIMELINE_TEMPLATE, newInstanceId, newRunId);
+        break;
+      }
+    }
+
+    if (newInstanceId != DO_NOTHING_CODE) {
+      stopSerialLatestOnlyQueuedInstance(conn, workflowId, newInstanceId, newRunId, messages);
+    }
+
+    try (PreparedStatement insertStmt = conn.prepareStatement(INSERT_WORKFLOW_INSTANCE_QUERY);
+        PreparedStatement stopStmt =
+            conn.prepareStatement(INSERT_STOPPED_WORKFLOW_INSTANCE_QUERY)) {
+      int idx = 0;
+      for (WorkflowInstance inst : instances) {
+        if (inst.getWorkflowInstanceId() != DO_NOTHING_CODE) {
+          if (!firstInserted) {
+            prepareCreateInstanceStatement(insertStmt, inst);
+            insertStmt.addBatch();
+            ret[idx] = SUCCESS_WRITE_SIZE;
+            firstInserted = true;
+          } else {
+            prepareStopInstanceStatement(stopStmt, inst, timelineEvent);
+            stopStmt.addBatch();
+            ret[idx] = -SUCCESS_WRITE_SIZE;
+            stoppedInstances.add(inst);
+          }
+        }
+        ++idx;
+      }
+
+      if (firstInserted) {
+        int[] insertRes = insertStmt.executeBatch();
+        Checks.checkTrue(
+            Arrays.stream(insertRes).allMatch(i -> i == SUCCESS_WRITE_SIZE),
+            "executeBatch in startSerialLatestOnlyInstances insert should return all 1s.");
+      }
+      if (!stoppedInstances.isEmpty()) {
+        int[] stopRes = stopStmt.executeBatch();
+        Checks.checkTrue(
+            Arrays.stream(stopRes).allMatch(i -> i == SUCCESS_WRITE_SIZE),
+            "executeBatch in startSerialLatestOnlyInstances stop should return all 1s.");
+        messages.add(
+            queueSystem.enqueue(
+                conn,
+                WorkflowInstanceUpdateJobEvent.create(
+                    stoppedInstances,
+                    WorkflowInstance.Status.STOPPED,
+                    System.currentTimeMillis())));
+      }
+    }
+
+    if (firstInserted) {
+      publishStartWorkflowJobEvent(conn, workflowId, messages);
+    }
+
+    // restore original order
+    Collections.reverse(instances);
+    int tmp;
+    for (int i = 0, j = ret.length - 1; i < j; ++i, --j) {
+      tmp = ret[i];
+      ret[i] = ret[j];
+      ret[j] = tmp;
+    }
+    return ret;
+  }
+
+  private void stopSerialLatestOnlyQueuedInstance(
+      Connection conn,
+      String workflowId,
+      long newInstanceId,
+      long newRunId,
+      List<MessageDto> messages)
+      throws SQLException {
+    try (PreparedStatement wfiStmt =
+        conn.prepareStatement(STOP_SERIAL_LATEST_ONLY_QUEUED_INSTANCE_QUERY)) {
+      wfiStmt.setString(
+          1,
+          toJson(
+              TimelineLogEvent.info(
+                  SERIAL_LATEST_ONLY_TIMELINE_TEMPLATE, newInstanceId, newRunId)));
+      wfiStmt.setString(2, workflowId);
+      List<WorkflowInstance> stopped = new ArrayList<>();
+      try (ResultSet result = wfiStmt.executeQuery()) {
+        while (result.next()) {
+          stopped.add(fromJson(result.getString(1), WorkflowInstance.class));
+        }
+      }
+      if (!stopped.isEmpty()) {
+        messages.add(
+            queueSystem.enqueue(
+                conn,
+                WorkflowInstanceUpdateJobEvent.create(
+                    stopped, WorkflowInstance.Status.STOPPED, System.currentTimeMillis())));
+        LOG.info(
+            "With SERIAL_LATEST_ONLY run strategy, stopped [{}] queued instance(s) for workflow [{}]",
+            stopped.size(),
+            workflowId);
+      }
+    }
   }
 
   private int[] startFirstOrLastOnlyInstances(

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDao.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDao.java
@@ -939,6 +939,15 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
     return insertInstance(conn, instance, true, null, messages);
   }
 
+  /**
+   * Starts a batch of workflow instances under the SERIAL_LATEST_ONLY run strategy.
+   *
+   * <p>The batch is reversed so the last arrival (highest instance id) is processed first and
+   * becomes the sole queued candidate. All existing queued rows for the workflow and all earlier
+   * rows in the batch are stopped in the same transaction. A single {@link StartWorkflowJobEvent}
+   * is emitted for the new arrival. The instances list and the return array are restored to their
+   * original order before returning.
+   */
   private int[] startSerialLatestOnlyInstances(
       Connection conn,
       String workflowId,
@@ -948,33 +957,23 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
     Collections.reverse(instances);
     int[] ret = new int[instances.size()];
     List<WorkflowInstance> stoppedInstances = new ArrayList<>();
-    long newInstanceId = 0;
-    long newRunId = 0;
     TimelineEvent timelineEvent = null;
     boolean firstInserted = false;
-
-    // scan to find the new arrival identity before touching the DB
-    for (WorkflowInstance inst : instances) {
-      if (inst.getWorkflowInstanceId() != DO_NOTHING_CODE) {
-        newInstanceId = inst.getWorkflowInstanceId();
-        newRunId = inst.getWorkflowRunId();
-        timelineEvent =
-            TimelineLogEvent.info(SERIAL_LATEST_ONLY_TIMELINE_TEMPLATE, newInstanceId, newRunId);
-        break;
-      }
-    }
-
-    if (newInstanceId != DO_NOTHING_CODE) {
-      stopSerialLatestOnlyQueuedInstance(conn, workflowId, newInstanceId, newRunId, messages);
-    }
+    int idx = 0;
 
     try (PreparedStatement insertStmt = conn.prepareStatement(INSERT_WORKFLOW_INSTANCE_QUERY);
         PreparedStatement stopStmt =
             conn.prepareStatement(INSERT_STOPPED_WORKFLOW_INSTANCE_QUERY)) {
-      int idx = 0;
       for (WorkflowInstance inst : instances) {
         if (inst.getWorkflowInstanceId() != DO_NOTHING_CODE) {
           if (!firstInserted) {
+            stopSerialLatestOnlyQueuedInstance(
+                conn, workflowId, inst.getWorkflowInstanceId(), inst.getWorkflowRunId(), messages);
+            timelineEvent =
+                TimelineLogEvent.info(
+                    SERIAL_LATEST_ONLY_TIMELINE_TEMPLATE,
+                    inst.getWorkflowInstanceId(),
+                    inst.getWorkflowRunId());
             prepareCreateInstanceStatement(insertStmt, inst);
             insertStmt.addBatch();
             ret[idx] = SUCCESS_WRITE_SIZE;
@@ -1014,7 +1013,6 @@ public class MaestroRunStrategyDao extends AbstractDatabaseDao {
       publishStartWorkflowJobEvent(conn, workflowId, messages);
     }
 
-    // restore original order
     Collections.reverse(instances);
     int tmp;
     for (int i = 0, j = ret.length - 1; i < j; ++i, --j) {

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDaoTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDaoTest.java
@@ -46,6 +46,8 @@ import com.netflix.maestro.queue.jobevents.TerminateThenRunJobEvent;
 import com.netflix.maestro.queue.jobevents.WorkflowInstanceUpdateJobEvent;
 import com.netflix.maestro.queue.jobevents.WorkflowVersionUpdateJobEvent;
 import com.netflix.maestro.queue.models.MessageDto;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -558,6 +560,219 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     assertNull(ret);
     ret = runStrategyDao.dequeueWithRunStrategy(TEST_WORKFLOW_ID, RunStrategy.create("LAST_ONLY"));
     assertNull(ret);
+    ret =
+        runStrategyDao.dequeueWithRunStrategy(
+            TEST_WORKFLOW_ID, RunStrategy.create("SERIAL_LATEST_ONLY"));
+    assertEquals(1, ret.size());
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+  }
+
+  private void markInstanceRunning(long instanceId, long runId) {
+    try (Connection conn = DATA_SOURCE.getConnection();
+        PreparedStatement stmt =
+            conn.prepareStatement(
+                "UPDATE maestro_workflow_instance SET execution_id='test-execution-id' "
+                    + "WHERE workflow_id=? AND instance_id=? AND run_id=?")) {
+      stmt.setString(1, TEST_WORKFLOW_ID);
+      stmt.setLong(2, instanceId);
+      stmt.setLong(3, runId);
+      stmt.executeUpdate();
+      conn.commit();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testStartRunStrategyWithSerialLatestOnly() {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    markInstanceRunning(1, 1);
+
+    // first arrival - no existing queued row, inserts as CREATED
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("slo-uuid-1");
+    int res = runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(1, res);
+    assertEquals(2, wfi.getWorkflowInstanceId());
+    assertEquals(1, wfi.getWorkflowRunId());
+    WorkflowInstance queued = dao.getLatestWorkflowInstanceRun(TEST_WORKFLOW_ID, 2);
+    assertEquals(WorkflowInstance.Status.CREATED, queued.getStatus());
+    verifyEnqueue(1, 0, 0);
+
+    // second arrival - stops the queued row, inserts as CREATED
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("slo-uuid-2");
+    res = runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(1, res);
+    assertEquals(3, wfi.getWorkflowInstanceId());
+    assertEquals(1, wfi.getWorkflowRunId());
+    WorkflowInstance previousQueued = dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 2, 1);
+    assertEquals(WorkflowInstance.Status.STOPPED, previousQueued.getStatus());
+    assertEquals(
+        "new instance 3 with run 1 arrived.\"]",
+        previousQueued
+            .getTimeline()
+            .getTimelineEvents()
+            .getFirst()
+            .getMessage()
+            .split("because ")[1]);
+    WorkflowInstance newQueued = dao.getLatestWorkflowInstanceRun(TEST_WORKFLOW_ID, 3);
+    assertEquals(WorkflowInstance.Status.CREATED, newQueued.getStatus());
+    verifyEnqueue(1, 0, 1);
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 3);
+  }
+
+  @Test
+  public void testStartRunStrategyWithSerialLatestOnlyNoQueuedYet() {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    markInstanceRunning(1, 1);
+
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("slo-uuid-nq");
+    int res = runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(1, res);
+    assertEquals(2, wfi.getWorkflowInstanceId());
+    assertEquals(1, wfi.getWorkflowRunId());
+    WorkflowInstance queued = dao.getLatestWorkflowInstanceRun(TEST_WORKFLOW_ID, 2);
+    assertEquals(WorkflowInstance.Status.CREATED, queued.getStatus());
+    verifyEnqueue(1, 0, 0);
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+  }
+
+  @Test
+  public void testStartRunStrategyWithSerialLatestOnlyStopsAllQueued() throws Exception {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    markInstanceRunning(1, 1);
+
+    // enqueue instances 2 and 3 via SEQUENTIAL (simulating a post-switch state)
+    RunStrategy sequential = RunStrategy.create("SEQUENTIAL");
+    WorkflowInstance wfi2 = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
+    wfi2.setWorkflowInstanceId(0);
+    wfi2.setWorkflowUuid("slo-stale-uuid-2");
+    runStrategyDao.startWithRunStrategy(wfi2, sequential);
+    assertEquals(2, wfi2.getWorkflowInstanceId());
+    verifyEnqueue(1, 0, 0);
+
+    WorkflowInstance wfi3 = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
+    wfi3.setWorkflowInstanceId(0);
+    wfi3.setWorkflowUuid("slo-stale-uuid-3");
+    runStrategyDao.startWithRunStrategy(wfi3, sequential);
+    assertEquals(3, wfi3.getWorkflowInstanceId());
+    verifyEnqueue(1, 0, 0);
+
+    // new arrival under SLO should stop both queued rows
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("slo-new-uuid-4");
+    int res = runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(1, res);
+    assertEquals(4, wfi.getWorkflowInstanceId());
+    assertEquals(
+        WorkflowInstance.Status.STOPPED,
+        dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 2, 1).getStatus());
+    assertEquals(
+        WorkflowInstance.Status.STOPPED,
+        dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 3, 1).getStatus());
+    assertEquals(
+        WorkflowInstance.Status.CREATED,
+        dao.getLatestWorkflowInstanceRun(TEST_WORKFLOW_ID, 4).getStatus());
+    verifyEnqueue(1, 0, 1);
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 3);
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 4);
+  }
+
+  @Test
+  public void testStartBatchRunStrategyWithSerialLatestOnly() throws Exception {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    List<WorkflowInstance> batch = prepareBatch();
+    int[] res = runStrategyDao.startBatchWithRunStrategy(TEST_WORKFLOW_ID, slo, batch);
+    // batch [wfi1-uuid, wfi1-uuid(dup), wfi3-uuid] reversed to [wfi3, dup, wfi1]
+    // wfi3 inserted as CREATED, wfi1 inserted as STOPPED; dup is skipped
+    assertArrayEquals(new int[] {-1, 0, 1}, res);
+    assertEquals(1, batch.get(0).getWorkflowInstanceId());
+    assertEquals(0, batch.get(1).getWorkflowInstanceId());
+    assertEquals(2, batch.get(2).getWorkflowInstanceId());
+
+    WorkflowInstance stopped = dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 1, 1);
+    assertEquals(WorkflowInstance.Status.STOPPED, stopped.getStatus());
+    WorkflowInstance created = dao.getLatestWorkflowInstanceRun(TEST_WORKFLOW_ID, 2);
+    assertEquals(WorkflowInstance.Status.CREATED, created.getStatus());
+    verifyEnqueue(1, 0, 1);
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+  }
+
+  @Test
+  public void testStartRunStrategyWithSerialLatestOnlyHonorsRestart() {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+
+    // mark instance 1 as terminal so it is restartable
+    dao.tryTerminateQueuedInstance(wfi, WorkflowInstance.Status.FAILED, "force to failed");
+    verifyEnqueue(0, 0, 1);
+
+    // insert a queued fresh instance (instance_id=2)
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("slo-fresh-uuid");
+    runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(2, wfi.getWorkflowInstanceId());
+    verifyEnqueue(1, 0, 0);
+
+    // restart instance 1 (new run_id=2) - should stop the queued fresh instance (instance_id=2)
+    wfi.setWorkflowInstanceId(1L);
+    wfi.setWorkflowRunId(0L);
+    wfi.setWorkflowUuid("slo-restart-uuid");
+    wfi.setRunConfig(new RunConfig());
+    wfi.getRunConfig().setPolicy(RunPolicy.RESTART_FROM_INCOMPLETE);
+    int res = runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(1, res);
+    assertEquals(1, wfi.getWorkflowInstanceId());
+    assertEquals(2, wfi.getWorkflowRunId());
+
+    WorkflowInstance previousQueued = dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 2, 1);
+    assertEquals(WorkflowInstance.Status.STOPPED, previousQueued.getStatus());
+    WorkflowInstance newQueued = dao.getLatestWorkflowInstanceRun(TEST_WORKFLOW_ID, 1);
+    assertEquals(WorkflowInstance.Status.CREATED, newQueued.getStatus());
+    assertEquals(2, newQueued.getWorkflowRunId());
+    verifyEnqueue(1, 0, 1);
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+  }
+
+  @Test
+  public void testDequeueWithSerialLatestOnlyReturnsQueued() {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    dao.tryTerminateQueuedInstance(wfi, WorkflowInstance.Status.SUCCEEDED, "complete");
+    verifyEnqueue(0, 0, 1);
+
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("slo-dequeue-uuid");
+    runStrategyDao.startWithRunStrategy(wfi, slo);
+    verifyEnqueue(1, 0, 0);
+
+    var ret = runStrategyDao.dequeueWithRunStrategy(TEST_WORKFLOW_ID, slo);
+    assertEquals(1, ret.size());
+    assertEquals(2, ret.getFirst().getInstanceId());
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+  }
+
+  @Test
+  public void testDequeueWithSerialLatestOnlyEmptyWhenRunning() {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    markInstanceRunning(1, 1);
+
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("slo-dequeue-running-uuid");
+    runStrategyDao.startWithRunStrategy(wfi, slo);
+    verifyEnqueue(1, 0, 0);
+
+    var ret = runStrategyDao.dequeueWithRunStrategy(TEST_WORKFLOW_ID, slo);
+    assertEquals(0, ret.size());
 
     MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
   }

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDaoTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDaoTest.java
@@ -589,9 +589,8 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
     markInstanceRunning(1, 1);
 
-    // first arrival - no existing queued row, inserts as CREATED
     wfi.setWorkflowInstanceId(0);
-    wfi.setWorkflowUuid("slo-uuid-1");
+    wfi.setWorkflowUuid("test-uuid-1");
     int res = runStrategyDao.startWithRunStrategy(wfi, slo);
     assertEquals(1, res);
     assertEquals(2, wfi.getWorkflowInstanceId());
@@ -600,9 +599,8 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     assertEquals(WorkflowInstance.Status.CREATED, queued.getStatus());
     verifyEnqueue(1, 0, 0);
 
-    // second arrival - stops the queued row, inserts as CREATED
     wfi.setWorkflowInstanceId(0);
-    wfi.setWorkflowUuid("slo-uuid-2");
+    wfi.setWorkflowUuid("test-uuid-2");
     res = runStrategyDao.startWithRunStrategy(wfi, slo);
     assertEquals(1, res);
     assertEquals(3, wfi.getWorkflowInstanceId());
@@ -631,7 +629,7 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     markInstanceRunning(1, 1);
 
     wfi.setWorkflowInstanceId(0);
-    wfi.setWorkflowUuid("slo-uuid-nq");
+    wfi.setWorkflowUuid("test-uuid");
     int res = runStrategyDao.startWithRunStrategy(wfi, slo);
     assertEquals(1, res);
     assertEquals(2, wfi.getWorkflowInstanceId());
@@ -648,25 +646,23 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
     markInstanceRunning(1, 1);
 
-    // enqueue instances 2 and 3 via SEQUENTIAL (simulating a post-switch state)
     RunStrategy sequential = RunStrategy.create("SEQUENTIAL");
     WorkflowInstance wfi2 = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
     wfi2.setWorkflowInstanceId(0);
-    wfi2.setWorkflowUuid("slo-stale-uuid-2");
+    wfi2.setWorkflowUuid("test-uuid-2");
     runStrategyDao.startWithRunStrategy(wfi2, sequential);
     assertEquals(2, wfi2.getWorkflowInstanceId());
     verifyEnqueue(1, 0, 0);
 
     WorkflowInstance wfi3 = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
     wfi3.setWorkflowInstanceId(0);
-    wfi3.setWorkflowUuid("slo-stale-uuid-3");
+    wfi3.setWorkflowUuid("test-uuid-3");
     runStrategyDao.startWithRunStrategy(wfi3, sequential);
     assertEquals(3, wfi3.getWorkflowInstanceId());
     verifyEnqueue(1, 0, 0);
 
-    // new arrival under SLO should stop both queued rows
     wfi.setWorkflowInstanceId(0);
-    wfi.setWorkflowUuid("slo-new-uuid-4");
+    wfi.setWorkflowUuid("test-uuid-4");
     int res = runStrategyDao.startWithRunStrategy(wfi, slo);
     assertEquals(1, res);
     assertEquals(4, wfi.getWorkflowInstanceId());
@@ -691,8 +687,6 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
     List<WorkflowInstance> batch = prepareBatch();
     int[] res = runStrategyDao.startBatchWithRunStrategy(TEST_WORKFLOW_ID, slo, batch);
-    // batch [wfi1-uuid, wfi1-uuid(dup), wfi3-uuid] reversed to [wfi3, dup, wfi1]
-    // wfi3 inserted as CREATED, wfi1 inserted as STOPPED; dup is skipped
     assertArrayEquals(new int[] {-1, 0, 1}, res);
     assertEquals(1, batch.get(0).getWorkflowInstanceId());
     assertEquals(0, batch.get(1).getWorkflowInstanceId());
@@ -712,24 +706,21 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
     markInstanceRunning(1, 1);
 
-    // enqueue instances 2 and 3 via SEQUENTIAL before the batch arrives
     RunStrategy sequential = RunStrategy.create("SEQUENTIAL");
     WorkflowInstance wfi2 = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
     wfi2.setWorkflowInstanceId(0);
-    wfi2.setWorkflowUuid("slo-stale-batch-uuid-2");
+    wfi2.setWorkflowUuid("test-uuid-2");
     runStrategyDao.startWithRunStrategy(wfi2, sequential);
     assertEquals(2, wfi2.getWorkflowInstanceId());
     verifyEnqueue(1, 0, 0);
 
     WorkflowInstance wfi3 = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
     wfi3.setWorkflowInstanceId(0);
-    wfi3.setWorkflowUuid("slo-stale-batch-uuid-3");
+    wfi3.setWorkflowUuid("test-uuid-3");
     runStrategyDao.startWithRunStrategy(wfi3, sequential);
     assertEquals(3, wfi3.getWorkflowInstanceId());
     verifyEnqueue(1, 0, 0);
 
-    // batch under SLO: last batch row becomes CREATED, first becomes STOPPED, pre-existing queued
-    // rows 2 and 3 are also stopped
     List<WorkflowInstance> batch = prepareBatch();
     int[] res = runStrategyDao.startBatchWithRunStrategy(TEST_WORKFLOW_ID, slo, batch);
     assertArrayEquals(new int[] {-1, 0, 1}, res);
@@ -749,8 +740,6 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     assertEquals(
         WorkflowInstance.Status.CREATED,
         dao.getLatestWorkflowInstanceRun(TEST_WORKFLOW_ID, 5).getStatus());
-    // one WorkflowInstanceUpdateJobEvent for pre-existing queued rows 2+3, one for batch-stopped
-    // row 4, one StartWorkflowJobEvent
     verifyEnqueue(1, 0, 2);
 
     MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
@@ -762,36 +751,30 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
   @Test
   public void testStartBatchRunStrategyWithSerialLatestOnlyAllDuplicates() throws Exception {
     RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
-    // batch where all UUIDs already exist — seed row has the existing uuid
     WorkflowInstance dup = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
     dup.setWorkflowInstanceId(0);
-    dup.setWorkflowUuid(wfi.getWorkflowUuid()); // same uuid as seed
+    dup.setWorkflowUuid(wfi.getWorkflowUuid());
     List<WorkflowInstance> batch = Collections.singletonList(dup);
     int[] res = runStrategyDao.startBatchWithRunStrategy(TEST_WORKFLOW_ID, slo, batch);
     assertArrayEquals(new int[] {0}, res);
-    // no new instance created, no events emitted
     verifyEnqueue(0, 0, 0);
   }
 
   @Test
   public void testStartRunStrategyWithSerialLatestOnlyHonorsRestart() {
     RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
-
-    // mark instance 1 as terminal so it is restartable
     dao.tryTerminateQueuedInstance(wfi, WorkflowInstance.Status.FAILED, "force to failed");
     verifyEnqueue(0, 0, 1);
 
-    // insert a queued fresh instance (instance_id=2)
     wfi.setWorkflowInstanceId(0);
-    wfi.setWorkflowUuid("slo-fresh-uuid");
+    wfi.setWorkflowUuid("test-uuid");
     runStrategyDao.startWithRunStrategy(wfi, slo);
     assertEquals(2, wfi.getWorkflowInstanceId());
     verifyEnqueue(1, 0, 0);
 
-    // restart instance 1 (new run_id=2) - should stop the queued fresh instance (instance_id=2)
     wfi.setWorkflowInstanceId(1L);
     wfi.setWorkflowRunId(0L);
-    wfi.setWorkflowUuid("slo-restart-uuid");
+    wfi.setWorkflowUuid("test-uuid-1");
     wfi.setRunConfig(new RunConfig());
     wfi.getRunConfig().setPolicy(RunPolicy.RESTART_FROM_INCOMPLETE);
     int res = runStrategyDao.startWithRunStrategy(wfi, slo);
@@ -816,7 +799,7 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     verifyEnqueue(0, 0, 1);
 
     wfi.setWorkflowInstanceId(0);
-    wfi.setWorkflowUuid("slo-dequeue-uuid");
+    wfi.setWorkflowUuid("test-uuid");
     runStrategyDao.startWithRunStrategy(wfi, slo);
     verifyEnqueue(1, 0, 0);
 
@@ -833,7 +816,7 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     markInstanceRunning(1, 1);
 
     wfi.setWorkflowInstanceId(0);
-    wfi.setWorkflowUuid("slo-dequeue-running-uuid");
+    wfi.setWorkflowUuid("test-uuid");
     runStrategyDao.startWithRunStrategy(wfi, slo);
     verifyEnqueue(1, 0, 0);
 
@@ -841,6 +824,68 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
     assertEquals(0, ret.size());
 
     MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+  }
+
+  @Test
+  public void testDequeueWithSerialLatestOnlyUnblocksAfterRunningTerminates() {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    markInstanceRunning(1, 1);
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("test-uuid");
+    runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(2, wfi.getWorkflowInstanceId());
+    verifyEnqueue(1, 0, 0);
+
+    var ret = runStrategyDao.dequeueWithRunStrategy(TEST_WORKFLOW_ID, slo);
+    assertEquals(0, ret.size());
+
+    WorkflowSummary summary = new WorkflowSummary();
+    summary.setWorkflowId(TEST_WORKFLOW_ID);
+    summary.setWorkflowInstanceId(1L);
+    summary.setWorkflowRunId(1L);
+    dao.updateWorkflowInstance(summary, null, null, WorkflowInstance.Status.SUCCEEDED, 123L, null);
+    reset(queueSystem);
+
+    ret = runStrategyDao.dequeueWithRunStrategy(TEST_WORKFLOW_ID, slo);
+    assertEquals(1, ret.size());
+    assertEquals(2, ret.getFirst().getInstanceId());
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+  }
+
+  @Test
+  public void testDequeueWithSerialLatestOnlyPicksLatestAfterCollapse() {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    markInstanceRunning(1, 1);
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("test-uuid-1");
+    runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(2, wfi.getWorkflowInstanceId());
+    verifyEnqueue(1, 0, 0);
+
+    wfi.setWorkflowInstanceId(0);
+    wfi.setWorkflowUuid("test-uuid-2");
+    runStrategyDao.startWithRunStrategy(wfi, slo);
+    assertEquals(3, wfi.getWorkflowInstanceId());
+    verifyEnqueue(1, 0, 1);
+
+    assertEquals(
+        WorkflowInstance.Status.STOPPED,
+        dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 2, 1).getStatus());
+
+    WorkflowSummary summary = new WorkflowSummary();
+    summary.setWorkflowId(TEST_WORKFLOW_ID);
+    summary.setWorkflowInstanceId(1L);
+    summary.setWorkflowRunId(1L);
+    dao.updateWorkflowInstance(summary, null, null, WorkflowInstance.Status.SUCCEEDED, 123L, null);
+    reset(queueSystem);
+
+    var ret = runStrategyDao.dequeueWithRunStrategy(TEST_WORKFLOW_ID, slo);
+    assertEquals(1, ret.size());
+    assertEquals(3, ret.getFirst().getInstanceId());
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 3);
   }
 
   @Test

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDaoTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroRunStrategyDaoTest.java
@@ -708,6 +708,72 @@ public class MaestroRunStrategyDaoTest extends MaestroDaoBaseTest {
   }
 
   @Test
+  public void testStartBatchRunStrategyWithSerialLatestOnlyStopsAllQueued() throws Exception {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    markInstanceRunning(1, 1);
+
+    // enqueue instances 2 and 3 via SEQUENTIAL before the batch arrives
+    RunStrategy sequential = RunStrategy.create("SEQUENTIAL");
+    WorkflowInstance wfi2 = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
+    wfi2.setWorkflowInstanceId(0);
+    wfi2.setWorkflowUuid("slo-stale-batch-uuid-2");
+    runStrategyDao.startWithRunStrategy(wfi2, sequential);
+    assertEquals(2, wfi2.getWorkflowInstanceId());
+    verifyEnqueue(1, 0, 0);
+
+    WorkflowInstance wfi3 = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
+    wfi3.setWorkflowInstanceId(0);
+    wfi3.setWorkflowUuid("slo-stale-batch-uuid-3");
+    runStrategyDao.startWithRunStrategy(wfi3, sequential);
+    assertEquals(3, wfi3.getWorkflowInstanceId());
+    verifyEnqueue(1, 0, 0);
+
+    // batch under SLO: last batch row becomes CREATED, first becomes STOPPED, pre-existing queued
+    // rows 2 and 3 are also stopped
+    List<WorkflowInstance> batch = prepareBatch();
+    int[] res = runStrategyDao.startBatchWithRunStrategy(TEST_WORKFLOW_ID, slo, batch);
+    assertArrayEquals(new int[] {-1, 0, 1}, res);
+    assertEquals(4, batch.get(0).getWorkflowInstanceId());
+    assertEquals(0, batch.get(1).getWorkflowInstanceId());
+    assertEquals(5, batch.get(2).getWorkflowInstanceId());
+
+    assertEquals(
+        WorkflowInstance.Status.STOPPED,
+        dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 2, 1).getStatus());
+    assertEquals(
+        WorkflowInstance.Status.STOPPED,
+        dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 3, 1).getStatus());
+    assertEquals(
+        WorkflowInstance.Status.STOPPED,
+        dao.getWorkflowInstanceRun(TEST_WORKFLOW_ID, 4, 1).getStatus());
+    assertEquals(
+        WorkflowInstance.Status.CREATED,
+        dao.getLatestWorkflowInstanceRun(TEST_WORKFLOW_ID, 5).getStatus());
+    // one WorkflowInstanceUpdateJobEvent for pre-existing queued rows 2+3, one for batch-stopped
+    // row 4, one StartWorkflowJobEvent
+    verifyEnqueue(1, 0, 2);
+
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 2);
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 3);
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 4);
+    MaestroTestHelper.removeWorkflowInstance(DATA_SOURCE, TEST_WORKFLOW_ID, 5);
+  }
+
+  @Test
+  public void testStartBatchRunStrategyWithSerialLatestOnlyAllDuplicates() throws Exception {
+    RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
+    // batch where all UUIDs already exist — seed row has the existing uuid
+    WorkflowInstance dup = loadObject(TEST_WORKFLOW_INSTANCE, WorkflowInstance.class);
+    dup.setWorkflowInstanceId(0);
+    dup.setWorkflowUuid(wfi.getWorkflowUuid()); // same uuid as seed
+    List<WorkflowInstance> batch = Collections.singletonList(dup);
+    int[] res = runStrategyDao.startBatchWithRunStrategy(TEST_WORKFLOW_ID, slo, batch);
+    assertArrayEquals(new int[] {0}, res);
+    // no new instance created, no events emitted
+    verifyEnqueue(0, 0, 0);
+  }
+
+  @Test
   public void testStartRunStrategyWithSerialLatestOnlyHonorsRestart() {
     RunStrategy slo = RunStrategy.create("SERIAL_LATEST_ONLY");
 

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/utils/WorkflowHelperTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/utils/WorkflowHelperTest.java
@@ -91,6 +91,13 @@ public class WorkflowHelperTest extends MaestroEngineBaseTest {
             WorkflowDefinition.class);
     assertEquals(
         RunStrategy.Rule.PARALLEL, parallel.getPropertiesSnapshot().getRunStrategy().getRule());
+    WorkflowDefinition serialLatestOnly =
+        loadObject(
+            "fixtures/workflows/definition/sample-minimal-wf-run-strategy-serial-latest-only.json",
+            WorkflowDefinition.class);
+    assertEquals(
+        RunStrategy.Rule.SERIAL_LATEST_ONLY,
+        serialLatestOnly.getPropertiesSnapshot().getRunStrategy().getRule());
   }
 
   @Test


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

**SERIAL_LATEST_ONLY Run Strategy**

Adds a new run strategy that fills the gap between SEQUENTIAL and LAST_ONLY. It provides serial execution (one instance at a time) with eager stale-queue collapse, i.e when a new instance arrives, all existing queued instances are stopped  and the new one becomes the sole queued candidate. The running instance is never terminated by a new arrival.

This is useful for workflows where only the most recent trigger state matters and replaying a stale backlog is wasteful,  for example, periodic refresh, snapshot publish, or materialized-view rebuild jobs. The strategy is analogous to Airflow's `schedule + catchup=False + max_active_runs=1` combination.

Switching into SERIAL_LATEST_ONLY follows the same free-switch behavior as SEQUENTIAL, i.e no gate on the number of non-terminal instances. In-flight instances drain naturally after a strategy change, and the SLO contract takes effect on subsequent arrivals.

Tested locally. A few behaviors worth noting:
* Switching from PARALLEL to SERIAL_LATEST_ONLY follows the same semantics as switching from PARALLEL to SEQUENTIAL — running instances drain naturally and existing queued instances are left untouched until a new arrival triggers the collapse.
* Restarting an older instance produces a new run that is subject to the full SLO contract — any currently queued instance is stopped and the restart becomes the new queued candidate.