### PR TITLE
Support optional extra_info on tag permits

### DIFF
--- a/maestro-common/src/main/java/com/netflix/maestro/models/api/TagPermitRequest.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/api/TagPermitRequest.java
@@ -12,26 +12,64 @@
  */
 package com.netflix.maestro.models.api;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.netflix.maestro.utils.Checks;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Request to set a tag permit. */
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder(
     value = {"tag", "max_allowed"},
     alphabetic = true)
-@AllArgsConstructor
 @NoArgsConstructor
 @Data
 public class TagPermitRequest {
+  /** reserved fields cannot be set within extraInfo. */
+  private static final Set<String> RESERVED_FIELDS =
+      new HashSet<>(Arrays.asList("tag", "max_allowed"));
+
   @NotNull private String tag;
 
   @Min(value = 0, message = "maxAllowed value must be greater or equals thant zero.")
   private int maxAllowed;
+
+  private Map<String, Object> extraInfo = new LinkedHashMap<>();
+
+  /** set extra info with validation. */
+  public void setExtraInfo(Map<String, Object> extraInfo) {
+    if (extraInfo != null) {
+      Checks.checkTrue(
+          RESERVED_FIELDS.stream().noneMatch(extraInfo::containsKey),
+          "extra info %s cannot contain any reserved keys %s",
+          extraInfo.keySet(),
+          RESERVED_FIELDS);
+    }
+    this.extraInfo = extraInfo;
+  }
+
+  /** extraInfo includes optional extra information associated with the tag permit request. */
+  @JsonAnyGetter
+  public Map<String, Object> getExtraInfo() {
+    return extraInfo;
+  }
+
+  /** Add fields to extraInfo. */
+  @JsonAnySetter
+  public void add(String name, Object value) {
+    extraInfo.put(name, value);
+  }
 }

--- a/maestro-common/src/main/java/com/netflix/maestro/models/tagpermits/TagPermit.java
+++ b/maestro-common/src/main/java/com/netflix/maestro/models/tagpermits/TagPermit.java
@@ -12,11 +12,19 @@
  */
 package com.netflix.maestro.models.tagpermits;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.netflix.maestro.models.timeline.Timeline;
+import com.netflix.maestro.utils.Checks;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -29,14 +37,48 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public class TagPermit {
+  /** reserved fields cannot be set within extraInfo. */
+  private static final Set<String> RESERVED_FIELDS =
+      new HashSet<>(Arrays.asList("tag", "max_allowed", "timeline"));
+
   private String tag;
   private int maxAllowed;
   private Timeline timeline;
+  private Map<String, Object> extraInfo = new LinkedHashMap<>();
 
   /** Constructor. */
-  public TagPermit(String tag, int maxAllowed, Timeline timeline) {
+  public TagPermit(String tag, int maxAllowed, Timeline timeline, Map<String, Object> extraInfo) {
     this.tag = tag;
     this.maxAllowed = maxAllowed;
     this.timeline = timeline;
+    if (extraInfo != null) {
+      this.extraInfo = validateExtraInfo(extraInfo);
+    }
+  }
+
+  /** set extra info with validation. */
+  public void setExtraInfo(Map<String, Object> extraInfo) {
+    this.extraInfo = extraInfo == null ? new LinkedHashMap<>() : validateExtraInfo(extraInfo);
+  }
+
+  private static Map<String, Object> validateExtraInfo(Map<String, Object> extraInfo) {
+    Checks.checkTrue(
+        RESERVED_FIELDS.stream().noneMatch(extraInfo::containsKey),
+        "extra info %s cannot contain any reserved keys %s",
+        extraInfo.keySet(),
+        RESERVED_FIELDS);
+    return extraInfo;
+  }
+
+  /** extraInfo includes optional extra information associated with the tag permit. */
+  @JsonAnyGetter
+  public Map<String, Object> getExtraInfo() {
+    return extraInfo;
+  }
+
+  /** Add fields to extraInfo. */
+  @JsonAnySetter
+  public void add(String name, Object value) {
+    extraInfo.put(name, value);
   }
 }

--- a/maestro-common/src/testFixtures/resources/fixtures/api/sample-tag-permit-request.json
+++ b/maestro-common/src/testFixtures/resources/fixtures/api/sample-tag-permit-request.json
@@ -1,4 +1,5 @@
 {
   "tag": "tag1",
-  "max_allowed": 42
+  "max_allowed": 42,
+  "source": "test"
 }

--- a/maestro-common/src/testFixtures/resources/fixtures/tag_permits/sample-tag-permit.json
+++ b/maestro-common/src/testFixtures/resources/fixtures/tag_permits/sample-tag-permit.json
@@ -1,6 +1,7 @@
 {
   "tag": "tag1",
   "max_allowed": 42,
+  "source": "test",
   "timeline": [
     {
       "timestamp": 1758087046642,

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/concurrency/MaestroTagPermitManager.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/concurrency/MaestroTagPermitManager.java
@@ -23,6 +23,7 @@ import com.netflix.maestro.queue.MaestroQueueSystem;
 import com.netflix.maestro.queue.models.MessageDto;
 import com.netflix.maestro.utils.ObjectHelper;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 
@@ -105,10 +106,11 @@ public class MaestroTagPermitManager implements TagPermitManager {
    * @param tag tag name
    * @param limit tag permit limit
    * @param user user performing the operation
+   * @param extraInfo optional extra information associated with the tag permit
    */
   @Override
-  public void upsertTagPermit(String tag, int limit, User user) {
-    tagPermitDao.upsertTagPermit(tag, limit, user);
+  public void upsertTagPermit(String tag, int limit, User user, Map<String, Object> extraInfo) {
+    tagPermitDao.upsertTagPermit(tag, limit, user, extraInfo);
     wakeUpTagPermitTask(MaestroTagPermitTask.TAG_PERMIT_CHANGE_CODE);
   }
 

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/concurrency/TagPermitManager.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/concurrency/TagPermitManager.java
@@ -18,6 +18,7 @@ import com.netflix.maestro.models.definition.User;
 import com.netflix.maestro.models.tagpermits.TagPermit;
 import com.netflix.maestro.models.timeline.TimelineEvent;
 import java.util.List;
+import java.util.Map;
 
 /** Interface for tag permit manager. */
 public interface TagPermitManager {
@@ -35,7 +36,8 @@ public interface TagPermitManager {
         public void releaseTagPermits(String uuid) {}
 
         @Override
-        public void upsertTagPermit(String tag, int limit, User user) {}
+        public void upsertTagPermit(
+            String tag, int limit, User user, Map<String, Object> extraInfo) {}
 
         @Override
         public void removeTagPermit(String tag) {}
@@ -72,8 +74,9 @@ public interface TagPermitManager {
    * @param tag tag name
    * @param limit tag permit limit
    * @param user user performing the operation
+   * @param extraInfo optional extra information associated with the tag permit
    */
-  void upsertTagPermit(String tag, int limit, User user);
+  void upsertTagPermit(String tag, int limit, User user, Map<String, Object> extraInfo);
 
   /**
    * Remove the tag permit.

--- a/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroTagPermitDao.java
+++ b/maestro-engine/src/main/java/com/netflix/maestro/engine/dao/MaestroTagPermitDao.java
@@ -12,6 +12,7 @@
  */
 package com.netflix.maestro.engine.dao;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.maestro.database.AbstractDatabaseDao;
 import com.netflix.maestro.database.DatabaseConfiguration;
@@ -32,21 +33,22 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import javax.sql.DataSource;
 
 /** DAO for managing tag permit. */
 public class MaestroTagPermitDao extends AbstractDatabaseDao {
   private static final String UPSERT_TAG_PERMIT_QUERY =
-      "INSERT INTO maestro_tag_permit (tag,max_allowed,timeline) VALUES (?,?,ARRAY[?]) ON CONFLICT (tag) DO UPDATE "
-          + "SET status=0,max_allowed=EXCLUDED.max_allowed,timeline = CASE "
+      "INSERT INTO maestro_tag_permit (tag,max_allowed,timeline,extra_info) VALUES (?,?,ARRAY[?],?::jsonb) ON CONFLICT (tag) DO UPDATE "
+          + "SET status=0,max_allowed=EXCLUDED.max_allowed,extra_info=EXCLUDED.extra_info,timeline = CASE "
           + "WHEN array_length(maestro_tag_permit.timeline, 1)>=32 "
           + "THEN array_append(maestro_tag_permit.timeline[2:32],?) "
           + "ELSE array_append(maestro_tag_permit.timeline,?) END";
   private static final String MARK_REMOVE_TAG_PERMIT_QUERY =
       "UPDATE maestro_tag_permit SET status=1 WHERE tag=?";
   private static final String GET_TAG_PERMIT_QUERY =
-      "SELECT max_allowed,timeline FROM maestro_tag_permit WHERE tag=?";
+      "SELECT max_allowed,timeline,extra_info FROM maestro_tag_permit WHERE tag=?";
 
   private static final String GET_TAG_PERMITS_QUERY =
       "SELECT tag,max_allowed FROM maestro_tag_permit where TAG>? AND status>=6 ORDER BY tag ASC LIMIT ?";
@@ -82,7 +84,10 @@ public class MaestroTagPermitDao extends AbstractDatabaseDao {
   private static final String MARK_STEP_TAG_PERMITS_ACQUIRED_QUERY =
       "UPDATE maestro_step_tag_permit SET (status,acquire_ts)=(7,NOW()) WHERE uuid=? AND status=6";
 
-  private record TagPermitRecord(int maxAllowed, String[] events) {}
+  private record TagPermitRecord(int maxAllowed, String[] events, String extraInfoJson) {}
+
+  private static final TypeReference<Map<String, Object>> EXTRA_INFO_TYPE =
+      new TypeReference<>() {};
 
   /** Constructor for OutputDataDAO. */
   public MaestroTagPermitDao(
@@ -100,8 +105,9 @@ public class MaestroTagPermitDao extends AbstractDatabaseDao {
    * @param tag tag name
    * @param limit max allowed limit
    * @param user user who made the change
+   * @param extraInfo optional extra information associated with the tag permit
    */
-  public void upsertTagPermit(String tag, int limit, User user) {
+  public void upsertTagPermit(String tag, int limit, User user, Map<String, Object> extraInfo) {
     String timelineForInsert =
         toJson(
             TimelineLogEvent.info(
@@ -110,6 +116,7 @@ public class MaestroTagPermitDao extends AbstractDatabaseDao {
         toJson(
             TimelineLogEvent.info(
                 "User [%s] updated the tag permit to the new limit [%s]", user.getName(), limit));
+    String extraInfoJson = (extraInfo == null || extraInfo.isEmpty()) ? null : toJson(extraInfo);
     withMetricLogError(
         () ->
             withRetryableUpdate(
@@ -119,6 +126,7 @@ public class MaestroTagPermitDao extends AbstractDatabaseDao {
                   stmt.setString(++idx, tag);
                   stmt.setInt(++idx, limit);
                   stmt.setString(++idx, timelineForInsert);
+                  stmt.setString(++idx, extraInfoJson);
                   stmt.setString(++idx, timelineForUpdate);
                   stmt.setString(++idx, timelineForUpdate);
                 }),
@@ -156,9 +164,13 @@ public class MaestroTagPermitDao extends AbstractDatabaseDao {
                     stmt -> stmt.setString(1, tag),
                     rs -> {
                       if (rs.next()) {
-                        Array array = rs.getArray(2);
+                        int idx = 0;
+                        int maxAllowed = rs.getInt(++idx);
+                        Array array = rs.getArray(++idx);
+                        String extraInfoJson = rs.getString(++idx);
                         try {
-                          return new TagPermitRecord(rs.getInt(1), (String[]) array.getArray());
+                          return new TagPermitRecord(
+                              maxAllowed, (String[]) array.getArray(), extraInfoJson);
                         } finally {
                           array.free();
                         }
@@ -170,11 +182,16 @@ public class MaestroTagPermitDao extends AbstractDatabaseDao {
             "Failed get tag permit for tag: [{}]",
             tag);
     if (res != null) {
+      Map<String, Object> extraInfo =
+          (res.extraInfoJson() == null || res.extraInfoJson().isBlank())
+              ? null
+              : fromJson(res.extraInfoJson(), EXTRA_INFO_TYPE);
       return new TagPermit(
           tag,
           res.maxAllowed(),
           new Timeline(
-              Arrays.stream(res.events()).map(s -> fromJson(s, TimelineEvent.class)).toList()));
+              Arrays.stream(res.events()).map(s -> fromJson(s, TimelineEvent.class)).toList()),
+          extraInfo);
     }
     return null;
   }
@@ -266,7 +283,7 @@ public class MaestroTagPermitDao extends AbstractDatabaseDao {
                   List<TagPermit> res = new ArrayList<>();
                   while (rs.next()) {
                     int idx = 0;
-                    res.add(new TagPermit(rs.getString(++idx), rs.getInt(++idx), null));
+                    res.add(new TagPermit(rs.getString(++idx), rs.getInt(++idx), null, null));
                   }
                   return res;
                 }),
@@ -315,7 +332,7 @@ public class MaestroTagPermitDao extends AbstractDatabaseDao {
                 rs -> {
                   List<TagPermit> res = new ArrayList<>();
                   while (rs.next()) {
-                    res.add(new TagPermit(rs.getString(1), rs.getInt(2), null));
+                    res.add(new TagPermit(rs.getString(1), rs.getInt(2), null, null));
                   }
                   return res;
                 }),

--- a/maestro-engine/src/main/resources/db/migration/postgres/V202605281000__add_extra_info_to_tag_permit.sql
+++ b/maestro-engine/src/main/resources/db/migration/postgres/V202605281000__add_extra_info_to_tag_permit.sql
@@ -1,0 +1,2 @@
+ALTER TABLE maestro_tag_permit
+  ADD COLUMN IF NOT EXISTS extra_info JSONB DEFAULT NULL;

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/concurrency/MaestroTagPermitManagerTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/concurrency/MaestroTagPermitManagerTest.java
@@ -136,9 +136,9 @@ public class MaestroTagPermitManagerTest extends MaestroEngineBaseTest {
     int limit = 10;
     User user = User.builder().name("test-user").build();
 
-    tagPermitManager.upsertTagPermit(tag, limit, user);
+    tagPermitManager.upsertTagPermit(tag, limit, user, null);
 
-    verify(tagPermitDao, times(1)).upsertTagPermit(tag, limit, user);
+    verify(tagPermitDao, times(1)).upsertTagPermit(tag, limit, user, null);
     verify(queueSystem, times(1)).notify(any(MessageDto.class));
   }
 
@@ -154,7 +154,7 @@ public class MaestroTagPermitManagerTest extends MaestroEngineBaseTest {
 
   @Test
   public void testGetTagPermit() {
-    TagPermit expectedPermit = new TagPermit(tag, 5, new Timeline(Collections.emptyList()));
+    TagPermit expectedPermit = new TagPermit(tag, 5, new Timeline(Collections.emptyList()), null);
     when(tagPermitDao.getTagPermit(tag)).thenReturn(expectedPermit);
 
     TagPermit result = tagPermitManager.getTagPermit(tag);

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroTagPermitDaoTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/dao/MaestroTagPermitDaoTest.java
@@ -27,7 +27,9 @@ import com.netflix.maestro.models.tagpermits.TagPermit;
 import com.netflix.maestro.models.timeline.TimelineActionEvent;
 import com.netflix.maestro.models.timeline.TimelineLogEvent;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
@@ -65,7 +67,7 @@ public class MaestroTagPermitDaoTest extends MaestroDaoBaseTest {
 
   @Test
   public void testUpsertTagPermit() {
-    tagPermitDao.upsertTagPermit(tag1, 5, user);
+    tagPermitDao.upsertTagPermit(tag1, 5, user, null);
 
     // create a new tag permit
     TagPermit result = tagPermitDao.getTagPermit(tag1);
@@ -79,7 +81,7 @@ public class MaestroTagPermitDaoTest extends MaestroDaoBaseTest {
         result.getTimeline().getTimelineEvents().getFirst().getMessage());
 
     // Update with new limit
-    tagPermitDao.upsertTagPermit(tag1, 10, user);
+    tagPermitDao.upsertTagPermit(tag1, 10, user, null);
     result = tagPermitDao.getTagPermit(tag1);
     assertNotNull(result);
     assertEquals(10, result.getMaxAllowed());
@@ -91,7 +93,7 @@ public class MaestroTagPermitDaoTest extends MaestroDaoBaseTest {
 
   @Test
   public void testMarkRemoveTagPermit() {
-    tagPermitDao.upsertTagPermit(tag1, 5, user);
+    tagPermitDao.upsertTagPermit(tag1, 5, user, null);
 
     assertNotNull(tagPermitDao.getTagPermit(tag1));
     assertTrue(tagPermitDao.markRemoveTagPermit(tag1));
@@ -102,8 +104,46 @@ public class MaestroTagPermitDaoTest extends MaestroDaoBaseTest {
     // Tag permit should not exist
     assertNull(tagPermitDao.getTagPermit(tag1));
 
-    tagPermitDao.upsertTagPermit(tag1, 5, user);
+    tagPermitDao.upsertTagPermit(tag1, 5, user, null);
     assertNotNull(tagPermitDao.getTagPermit(tag1));
+  }
+
+  @Test
+  public void testUpsertTagPermitWithNullExtraInfo() {
+    tagPermitDao.upsertTagPermit(tag1, 5, user, null);
+
+    TagPermit result = tagPermitDao.getTagPermit(tag1);
+    assertNotNull(result);
+    assertEquals(Collections.emptyMap(), result.getExtraInfo());
+  }
+
+  @Test
+  public void testUpsertTagPermitWithEmptyExtraInfo() {
+    tagPermitDao.upsertTagPermit(tag1, 5, user, Collections.emptyMap());
+
+    TagPermit result = tagPermitDao.getTagPermit(tag1);
+    assertNotNull(result);
+    assertEquals(Collections.emptyMap(), result.getExtraInfo());
+  }
+
+  @Test
+  public void testUpsertTagPermitWithExtraInfo() {
+    Map<String, Object> extraInfo = Map.of("source", "test", "owners", List.of("alice", "bob"));
+    tagPermitDao.upsertTagPermit(tag1, 5, user, extraInfo);
+
+    TagPermit result = tagPermitDao.getTagPermit(tag1);
+    assertNotNull(result);
+    assertEquals(extraInfo, result.getExtraInfo());
+  }
+
+  @Test
+  public void testUpsertTagPermitOverwritesExtraInfo() {
+    tagPermitDao.upsertTagPermit(tag1, 5, user, Map.of("source", "first"));
+    tagPermitDao.upsertTagPermit(tag1, 5, user, Map.of("source", "second"));
+
+    TagPermit result = tagPermitDao.getTagPermit(tag1);
+    assertNotNull(result);
+    assertEquals(Map.of("source", "second"), result.getExtraInfo());
   }
 
   @Test
@@ -145,7 +185,7 @@ public class MaestroTagPermitDaoTest extends MaestroDaoBaseTest {
 
   @Test
   public void testGetSyncedTagPermits() {
-    tagPermitDao.upsertTagPermit(tag1, 5, user);
+    tagPermitDao.upsertTagPermit(tag1, 5, user, null);
     tagPermitDao.markAndLoadTagPermits(1);
 
     // Get synced tag permits
@@ -159,7 +199,7 @@ public class MaestroTagPermitDaoTest extends MaestroDaoBaseTest {
 
   @Test
   public void testRemoveTagPermits() {
-    tagPermitDao.upsertTagPermit(tag1, 5, user);
+    tagPermitDao.upsertTagPermit(tag1, 5, user, null);
     tagPermitDao.markRemoveTagPermit(tag1);
 
     List<String> removedTags = tagPermitDao.removeTagPermits(10);
@@ -172,8 +212,8 @@ public class MaestroTagPermitDaoTest extends MaestroDaoBaseTest {
   @Test
   public void testMarkAndLoadTagPermits() {
     // Create some tag permits
-    tagPermitDao.upsertTagPermit(tag1, 5, user);
-    tagPermitDao.upsertTagPermit(tag2, 10, user);
+    tagPermitDao.upsertTagPermit(tag1, 5, user, null);
+    tagPermitDao.upsertTagPermit(tag2, 10, user, null);
 
     // Mark and load tag permits
     List<TagPermit> permits = tagPermitDao.markAndLoadTagPermits(10);

--- a/maestro-engine/src/test/java/com/netflix/maestro/engine/tasks/MaestroTagPermitTaskTest.java
+++ b/maestro-engine/src/test/java/com/netflix/maestro/engine/tasks/MaestroTagPermitTaskTest.java
@@ -70,7 +70,7 @@ public class MaestroTagPermitTaskTest extends MaestroEngineBaseTest {
   @Test
   public void testStartLoadTagPermitsAndStepTagPermits() {
     List<TagPermit> tagPermits =
-        List.of(new TagPermit("tag1", 5, null), new TagPermit("tag2", 3, null));
+        List.of(new TagPermit("tag1", 5, null, null), new TagPermit("tag2", 3, null, null));
     when(tagPermitDao.getSyncedTagPermits(anyString(), anyInt()))
         .thenReturn(tagPermits)
         .thenReturn(List.of());
@@ -153,7 +153,7 @@ public class MaestroTagPermitTaskTest extends MaestroEngineBaseTest {
 
   @Test
   public void testTagPermitAssignmentWithAvailablePermits() {
-    List<TagPermit> tagPermits = List.of(new TagPermit("tag1", 2, null));
+    List<TagPermit> tagPermits = List.of(new TagPermit("tag1", 2, null, null));
     when(tagPermitDao.getSyncedTagPermits(anyString(), anyInt())).thenReturn(tagPermits);
 
     UUID stepUuid = UUID.randomUUID();
@@ -189,7 +189,7 @@ public class MaestroTagPermitTaskTest extends MaestroEngineBaseTest {
 
   @Test
   public void testTagPermitAssignmentWithLimitReached() {
-    List<TagPermit> tagPermits = List.of(new TagPermit("tag1", 1, null));
+    List<TagPermit> tagPermits = List.of(new TagPermit("tag1", 1, null, null));
     when(tagPermitDao.getSyncedTagPermits(anyString(), anyInt())).thenReturn(tagPermits);
 
     UUID acquiredUuid = UUID.randomUUID();

--- a/maestro-server/src/main/java/com/netflix/maestro/server/controllers/TagPermitController.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/controllers/TagPermitController.java
@@ -59,7 +59,10 @@ public class TagPermitController {
   @Operation(summary = "Create or update a tag permit.")
   public ResponseEntity<?> upsertTagPermit(@Valid @RequestBody TagPermitRequest tagPermitRequest) {
     tagPermitManager.upsertTagPermit(
-        tagPermitRequest.getTag(), tagPermitRequest.getMaxAllowed(), callerBuilder.build());
+        tagPermitRequest.getTag(),
+        tagPermitRequest.getMaxAllowed(),
+        callerBuilder.build(),
+        tagPermitRequest.getExtraInfo());
     return ResponseEntity.ok().build();
   }
 

--- a/maestro-server/src/test/java/com/netflix/maestro/server/controllers/TagPermitControllerTest.java
+++ b/maestro-server/src/test/java/com/netflix/maestro/server/controllers/TagPermitControllerTest.java
@@ -27,6 +27,7 @@ import com.netflix.maestro.models.definition.User;
 import com.netflix.maestro.models.tagpermits.TagPermit;
 import com.netflix.maestro.models.timeline.Timeline;
 import java.util.Collections;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -62,19 +63,45 @@ public class TagPermitControllerTest extends MaestroBaseTest {
     ArgumentCaptor<String> tagCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
     ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> extraInfoCaptor = ArgumentCaptor.forClass(Map.class);
 
     verify(tagPermitManager, times(1))
-        .upsertTagPermit(tagCaptor.capture(), limitCaptor.capture(), userCaptor.capture());
+        .upsertTagPermit(
+            tagCaptor.capture(),
+            limitCaptor.capture(),
+            userCaptor.capture(),
+            extraInfoCaptor.capture());
 
     assertEquals("test-tag", tagCaptor.getValue());
     assertEquals(Integer.valueOf(5), limitCaptor.getValue());
     assertEquals(testUser, userCaptor.getValue());
+    assertEquals(Collections.emptyMap(), extraInfoCaptor.getValue());
+  }
+
+  @Test
+  public void testUpsertTagPermitWithExtraInfo() {
+    TagPermitRequest request = new TagPermitRequest();
+    request.setTag("test-tag");
+    request.setMaxAllowed(5);
+    request.setExtraInfo(Map.of("source", "test"));
+
+    ResponseEntity<?> response = tagPermitController.upsertTagPermit(request);
+
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Map<String, Object>> extraInfoCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(tagPermitManager, times(1))
+        .upsertTagPermit(any(), any(Integer.class), any(), extraInfoCaptor.capture());
+    assertEquals(Map.of("source", "test"), extraInfoCaptor.getValue());
   }
 
   @Test
   public void testGetTagPermit() {
     String tag = "existing-tag";
-    TagPermit expectedTagPermit = new TagPermit(tag, 10, new Timeline(Collections.emptyList()));
+    TagPermit expectedTagPermit =
+        new TagPermit(tag, 10, new Timeline(Collections.emptyList()), null);
     when(tagPermitManager.getTagPermit(any())).thenReturn(expectedTagPermit);
 
     TagPermit result = tagPermitController.getTagPermit(tag);


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

- Added `extraInfo` (`Map<String, Object>`) to `TagPermitRequest` and `TagPermit` using the same `@JsonAnyGetter`/`@JsonAnySetter` pattern as `Metadata.extraInfo`, so caller-provided fields flatten to the top level of the JSON (no `extra_info` wrapper key on the wire).
- Wired the new field through `TagPermitManager.upsertTagPermit`, the DB DAO, and the controller. The new `extra_info JSONB` column is read/written only on the admin POST/GET paths; the tag-permit task's hot-loop SELECTs are intentionally left untouched.
- Added Flyway migration `V202605281000__add_extra_info_to_tag_permit.sql` to add the column with a `NULL` default.

Tested locally end-to-end,  POST + GET round-trip with extra info and without.
