### PR TITLE
Port inline foreach workflow instance endpoints from internal

### DIFF
--- a/maestro-server/src/main/java/com/netflix/maestro/server/controllers/WorkflowInstanceController.java
+++ b/maestro-server/src/main/java/com/netflix/maestro/server/controllers/WorkflowInstanceController.java
@@ -17,8 +17,17 @@ import com.netflix.maestro.models.Actions;
 import com.netflix.maestro.models.Constants;
 import com.netflix.maestro.models.api.PaginationDirection;
 import com.netflix.maestro.models.api.PaginationResult;
+import com.netflix.maestro.models.definition.ForeachStep;
+import com.netflix.maestro.models.definition.Step;
+import com.netflix.maestro.models.definition.StepType;
+import com.netflix.maestro.models.initiator.ForeachInitiator;
+import com.netflix.maestro.models.initiator.UpstreamInitiator;
 import com.netflix.maestro.models.instance.WorkflowInstance;
 import com.netflix.maestro.server.utils.PaginationHelper;
+import com.netflix.maestro.utils.Checks;
+import com.netflix.maestro.utils.HashHelper;
+import com.netflix.maestro.utils.IdHelper;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -27,12 +36,14 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -279,5 +290,100 @@ public class WorkflowInstanceController {
     }
 
     return new long[] {max, min}; // high, low
+  }
+
+  @Operation(
+      summary =
+          "Get the inline workflow id for a given node path, which includes the node info up to the non-inline parent")
+  @Hidden
+  @GetMapping(value = "/instances/inline-workflow-id")
+  public String getInlineWorkflowIdForStepWithinForeach(
+      @Valid @NotNull @RequestBody List<UpstreamInitiator.Info> nodePath) {
+    UpstreamInitiator.Info root = nodePath.get(0);
+    UpstreamInitiator.Info current = nodePath.get(nodePath.size() - 1);
+    WorkflowInstance instance =
+        workflowInstanceDao.getWorkflowInstanceRun(
+            root.getWorkflowId(), root.getInstanceId(), Constants.LATEST_ONE);
+
+    List<String> path = new ArrayList<>();
+    for (Step step : instance.getRuntimeWorkflow().getSteps()) {
+      if (getPathToStepId(step, current.getStepId(), path)) {
+        break;
+      }
+    }
+    Checks.checkTrue(
+        path.size() == nodePath.size() && path.size() > 1,
+        "Inline workflow step path [%s] is invalid for the input path [%s]",
+        path,
+        nodePath);
+
+    String inlineWorkflowId = root.getWorkflowId();
+    for (int i = 0; i < path.size() - 1; ++i) {
+      UpstreamInitiator.Info node = nodePath.get(i);
+      node.setStepId(path.get(i));
+      node.setWorkflowId(inlineWorkflowId);
+      inlineWorkflowId =
+          computeInlineWorkflowId(instance.getInternalId(), instance.getWorkflowInstanceId(), node);
+    }
+    return inlineWorkflowId;
+  }
+
+  private String computeInlineWorkflowId(
+      long internalId, long instanceId, UpstreamInitiator.Info node) {
+    return String.format(
+        "%s_%s_%s_%s",
+        Constants.FOREACH_INLINE_WORKFLOW_PREFIX,
+        IdHelper.hashKey(internalId),
+        IdHelper.rangeKey(instanceId),
+        HashHelper.md5(
+            node.getStepId(), String.valueOf(node.getInstanceId()), node.getWorkflowId()));
+  }
+
+  private boolean getPathToStepId(Step step, String target, List<String> path) {
+    if (target.equals(step.getId())) {
+      path.add(step.getId());
+      return true;
+    }
+
+    if (step.getType() == StepType.FOREACH) {
+      path.add(step.getId());
+      for (Step foreachStep : ((ForeachStep) step).getSteps()) {
+        if (getPathToStepId(foreachStep, target, path)) {
+          return true;
+        }
+      }
+      path.remove(path.size() - 1);
+    }
+    return false;
+  }
+
+  @Operation(
+      summary =
+          "Get the inline node path for a given foreach inline workflow instance. "
+              + "The path is rooted at the non-inline parent and expanded to the foreach instance itself.")
+  @Hidden
+  @GetMapping(
+      value = "/{workflowId}/instances/{workflowInstanceId}/inline-path",
+      consumes = MediaType.ALL_VALUE)
+  public List<UpstreamInitiator.Info> getForeachInitiatorForInlineWorkflowInstance(
+      @Valid @NotNull @PathVariable("workflowId") String workflowId,
+      @Valid @NotNull @PathVariable("workflowInstanceId") long workflowInstanceId) {
+    WorkflowInstance instance =
+        workflowInstanceDao.getWorkflowInstanceRun(
+            workflowId, workflowInstanceId, Constants.LATEST_ONE);
+    Checks.checkTrue(
+        instance.getInitiator() instanceof ForeachInitiator,
+        "This endpoint only supports getting ForeachInitiator for an inline workflow instance.");
+
+    ForeachInitiator foreachInitiator = (ForeachInitiator) instance.getInitiator();
+    UpstreamInitiator.Info nonInlineParent = foreachInitiator.getNonInlineParent();
+    while (!foreachInitiator.getRoot().equals(nonInlineParent)) {
+      foreachInitiator.getAncestors().remove(0);
+    }
+    UpstreamInitiator.Info current = new UpstreamInitiator.Info();
+    current.setWorkflowId(workflowId);
+    current.setInstanceId(workflowInstanceId);
+    foreachInitiator.getAncestors().add(current);
+    return foreachInitiator.getAncestors();
   }
 }

--- a/maestro-server/src/test/java/com/netflix/maestro/server/controllers/WorkflowInstanceControllerTest.java
+++ b/maestro-server/src/test/java/com/netflix/maestro/server/controllers/WorkflowInstanceControllerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.maestro.server.controllers;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.maestro.AssertHelper;
+import com.netflix.maestro.MaestroBaseTest;
+import com.netflix.maestro.engine.dao.MaestroWorkflowInstanceDao;
+import com.netflix.maestro.models.initiator.ForeachInitiator;
+import com.netflix.maestro.models.initiator.UpstreamInitiator;
+import com.netflix.maestro.models.instance.WorkflowInstance;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class WorkflowInstanceControllerTest extends MaestroBaseTest {
+  @Mock private MaestroWorkflowInstanceDao mockInstanceDao;
+
+  private WorkflowInstanceController workflowInstanceController;
+
+  @Before
+  public void before() {
+    this.mockInstanceDao = mock(MaestroWorkflowInstanceDao.class);
+    this.workflowInstanceController = new WorkflowInstanceController(this.mockInstanceDao);
+  }
+
+  @Test
+  public void testGetInlineWorkflowIdForStepWithinForeach() throws Exception {
+    WorkflowInstance instance =
+        loadObject(
+            "fixtures/instances/sample-workflow-instance-nested-inline-foreach.json",
+            WorkflowInstance.class);
+    instance.setWorkflowId("nested-foreach-wf1");
+    instance.setWorkflowInstanceId(20);
+    when(mockInstanceDao.getWorkflowInstanceRun("nested-foreach-wf1", 10, 0)).thenReturn(instance);
+    ForeachInitiator initiator = (ForeachInitiator) instance.getInitiator();
+    initiator.getAncestors().add(new UpstreamInitiator.Info());
+    initiator.getParent().setStepId("test-step1");
+    initiator.getParent().setInstanceId(7);
+
+    assertEquals(
+        "maestro_foreach_F3_1K_a9533975fe5e3b9ce03338237ddfa6a1",
+        workflowInstanceController.getInlineWorkflowIdForStepWithinForeach(
+            initiator.getAncestors()));
+
+    initiator.getParent().setStepId("not-existing");
+    AssertHelper.assertThrows(
+        "Inline workflow path is empty and invalid",
+        IllegalArgumentException.class,
+        "Inline workflow step path [[]] is invalid for the input path ",
+        () ->
+            workflowInstanceController.getInlineWorkflowIdForStepWithinForeach(
+                initiator.getAncestors()));
+
+    initiator.getParent().setStepId("test-step2");
+    AssertHelper.assertThrows(
+        "Inline workflow path length mismatch with the initiator",
+        IllegalArgumentException.class,
+        "Inline workflow step path [[root-step, test-step2]] is invalid for the input",
+        () ->
+            workflowInstanceController.getInlineWorkflowIdForStepWithinForeach(
+                initiator.getAncestors()));
+  }
+
+  @Test
+  public void getForeachInitiatorForInlineWorkflowInstance() throws Exception {
+    WorkflowInstance instance =
+        loadObject(
+            "fixtures/instances/sample-workflow-instance-nested-inline-foreach.json",
+            WorkflowInstance.class);
+    instance.setWorkflowInstanceId(20);
+    when(mockInstanceDao.getWorkflowInstanceRun("maestro_foreach_F3_1K_inline_instance", 7, 0))
+        .thenReturn(instance);
+
+    List<UpstreamInitiator.Info> path =
+        workflowInstanceController.getForeachInitiatorForInlineWorkflowInstance(
+            "maestro_foreach_F3_1K_inline_instance", 7);
+    assertEquals(3, path.size());
+    assertEquals("nested-foreach-wf1", path.get(0).getWorkflowId());
+    assertEquals(10, path.get(0).getInstanceId());
+    assertEquals(
+        Arrays.asList(10L, 3L, 7L),
+        path.stream().map(UpstreamInitiator.Info::getInstanceId).collect(Collectors.toList()));
+  }
+}


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

This is a port of functionality that already exists in the internal Maestro repository.

It brings over two `@Hidden` workflow-instance endpoints (and their unit tests) from internal to open source:

- `GET /api/v3/workflows/instances/inline-workflow-id` — resolves the foreach inline workflow id for a given node path (the path is provided up to the non-inline parent).
- `GET /api/v3/workflows/{workflowId}/instances/{workflowInstanceId}/inline-path` — returns the inline node path for a given foreach inline workflow instance, rooted at the non-inline parent and expanded to the instance itself.

Both endpoints are kept `@Hidden` (excluded from the published API docs), matching the internal implementation. The endpoint logic is ported as-is; the only adaptation is using the open-source `Checks.checkTrue` helper in place of the internal `Checks.isTrue`. The shared `sample-workflow-instance-nested-inline-foreach.json` test fixture already exists in this repo and is reused by the ported tests.
