### PR TITLE
Reject invalid foreach loop params

### DIFF
--- a/maestro-extensions/src/main/java/com/netflix/maestro/extensions/controllers/ForeachFlattenController.java
+++ b/maestro-extensions/src/main/java/com/netflix/maestro/extensions/controllers/ForeachFlattenController.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.maestro.annotations.Nullable;
 import com.netflix.maestro.annotations.SuppressFBWarnings;
+import com.netflix.maestro.exceptions.MaestroBadRequestException;
 import com.netflix.maestro.exceptions.MaestroNotFoundException;
 import com.netflix.maestro.extensions.dao.MaestroForeachFlattenedDao;
 import com.netflix.maestro.extensions.models.StepIteration;
@@ -119,12 +120,7 @@ public class ForeachFlattenController {
     int limit = (last == null) ? first : last;
 
     String iterationCursor = decodeCursor(cursor);
-    Map<String, String> loopParameters = null;
-    try {
-      loopParameters = getLoopParameters(loopParamsStr);
-    } catch (IOException ex) {
-      LOG.error("Failed to unmarshal loop params: [{}]", loopParamsStr, ex);
-    }
+    Map<String, String> loopParameters = getLoopParameters(loopParamsStr);
 
     List<StepIteration> stepIterations =
         dao.scanStepIterations(
@@ -212,12 +208,20 @@ public class ForeachFlattenController {
     return direction.equals(PaginationDirection.NEXT) || hasMoreItems;
   }
 
-  private Map<String, String> getLoopParameters(String loopParamsStr) throws IOException {
+  private Map<String, String> getLoopParameters(String loopParamsStr) {
     if (loopParamsStr == null || loopParamsStr.isEmpty()) {
       return null;
     }
-    return objectMapper.readValue(
-        Base64.getUrlDecoder().decode(loopParamsStr.getBytes(Charset.defaultCharset())), TYPE_REF);
+    try {
+      return objectMapper.readValue(
+          Base64.getUrlDecoder().decode(loopParamsStr.getBytes(Charset.defaultCharset())),
+          TYPE_REF);
+    } catch (IllegalArgumentException | IOException ex) {
+      throw new MaestroBadRequestException(
+          ex,
+          "Invalid loopParams query parameter",
+          "loopParams must be a URL-safe base64 encoded JSON object with string values");
+    }
   }
 
   private String encodeCursor(String str) {

--- a/maestro-extensions/src/test/java/com/netflix/maestro/extensions/controllers/ForeachFlattenControllerTest.java
+++ b/maestro-extensions/src/test/java/com/netflix/maestro/extensions/controllers/ForeachFlattenControllerTest.java
@@ -14,6 +14,7 @@ package com.netflix.maestro.extensions.controllers;
 
 import static org.junit.Assert.assertThrows;
 
+import com.netflix.maestro.exceptions.MaestroBadRequestException;
 import com.netflix.maestro.exceptions.MaestroNotFoundException;
 import com.netflix.maestro.extensions.ExtensionsBaseTest;
 import com.netflix.maestro.extensions.dao.MaestroForeachFlattenedDao;
@@ -22,8 +23,11 @@ import com.netflix.maestro.extensions.models.StepIterationsSummary;
 import com.netflix.maestro.models.api.PaginationResult;
 import com.netflix.maestro.models.instance.StepInstance;
 import com.netflix.maestro.models.instance.StepRuntimeState;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -104,6 +108,45 @@ public class ForeachFlattenControllerTest extends ExtensionsBaseTest {
     Assert.assertEquals(1, result.getElements().size());
     Assert.assertEquals(false, result.getPageInfo().isHasNextPage());
     Assert.assertEquals(true, result.getPageInfo().isHasPreviousPage());
+  }
+
+  @Test
+  public void testScanForwardWithLoopParams() throws Exception {
+    Map<String, String> loopParams = Collections.singletonMap("region", "us-west-2");
+    String encodedLoopParams =
+        Base64.getUrlEncoder().encodeToString(MAPPER.writeValueAsBytes(loopParams));
+    Mockito.when(
+            dao.scanStepIterations(
+                "wf1", 1, 1, "s", null, 2, true, loopParams, Collections.EMPTY_LIST))
+        .thenReturn(Collections.nCopies(1, stepIteration));
+    PaginationResult<StepIteration> result =
+        controller.getStepIterations(
+            "wf1", 1, 1, "s", 1, null, null, Collections.EMPTY_LIST, encodedLoopParams);
+    Assert.assertEquals(1, result.getElements().size());
+  }
+
+  @Test
+  public void testGetStepIterationsThrowsBadRequestForInvalidLoopParamsBase64() {
+    assertThrows(
+        "Invalid loopParams query parameter",
+        MaestroBadRequestException.class,
+        () ->
+            controller.getStepIterations(
+                "wf1", 1, 1, "s", 1, null, null, Collections.EMPTY_LIST, "%"));
+    Mockito.verifyNoInteractions(dao);
+  }
+
+  @Test
+  public void testGetStepIterationsThrowsBadRequestForInvalidLoopParamsJson() {
+    String invalidJson =
+        Base64.getUrlEncoder().encodeToString("{".getBytes(StandardCharsets.UTF_8));
+    assertThrows(
+        "Invalid loopParams query parameter",
+        MaestroBadRequestException.class,
+        () ->
+            controller.getStepIterations(
+                "wf1", 1, 1, "s", 1, null, null, Collections.EMPTY_LIST, invalidJson));
+    Mockito.verifyNoInteractions(dao);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Return a bad request when `loopParams` cannot be URL-safe base64 decoded or parsed as JSON.
- Preserve the current unfiltered behavior for omitted or empty `loopParams`.
- Add controller coverage for valid filters, invalid base64, and invalid JSON.

## Why
Malformed `loopParams` were previously logged and then passed to the DAO as `null`. The DAO treats `null` as no filter, so a bad filter could silently broaden the result set.

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew :maestro-extensions:test --tests com.netflix.maestro.extensions.controllers.ForeachFlattenControllerTest`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ./gradlew :maestro-extensions:spotlessCheck :maestro-extensions:checkstyleMain :maestro-extensions:pmdMain`

I also tried `:maestro-extensions:check`; local Docker/Testcontainers was unavailable for the DAO test, and SpotBugs reported existing findings in unrelated extension files.
